### PR TITLE
feat(settings): add display options for clock, date and battery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
-  "name": "ally-launcher",
+  "name": "liftoff",
   "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ally-launcher",
+      "name": "liftoff",
       "version": "1.2.2",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "i18next": "^26.0.8",
+        "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-i18next": "^17.0.4"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -251,6 +254,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -892,9 +904,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,9 +918,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -926,9 +932,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -943,9 +946,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,9 +960,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -977,9 +974,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -994,9 +988,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1011,9 +1002,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1028,9 +1016,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,9 +1030,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,9 +1044,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,9 +1058,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1096,9 +1072,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,9 +1261,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1308,9 +1278,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1295,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1368,9 +1329,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1708,6 +1666,52 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.0.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.8.tgz",
+      "integrity": "sha512-BRzLom0mhDhV9v0QhgUUHWQJuwFmnr1194xEcNLYD6ym8y8s542n4jXUvRLnhNTbh9PmpU6kGZamyuGHQMsGjw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1854,6 +1858,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+      "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.0.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1983,6 +2014,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -2056,6 +2096,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,14 +10,17 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-opener": "^2",
+    "i18next": "^26.0.8",
+    "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "react-i18next": "^17.0.4"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
     "@vitejs/plugin-react": "^4.6.0",
-    "vite": "^7.0.4",
-    "@tauri-apps/cli": "^2"
+    "vite": "^7.0.4"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1506,6 +1506,7 @@ export default function App() {
   const [date, setDate]                             = useState("");
   const [battery, setBattery]                       = useState(0);
   const [charging, setCharging]                     = useState(false);
+  const [hasBattery, setHasBattery]                 = useState(false);
   const [gameArt, setGameArt]                       = useState({});
   const [heroStatic, setHeroStatic]                 = useState({});
   const [heroAnimated, setHeroAnimated]             = useState({});
@@ -1523,7 +1524,7 @@ export default function App() {
     default_tab: "Home", scan_steam: true, scan_xbox: true,
     scan_uwp: true, scan_desktop: true, scan_battlenet: true, repeat_speed: "normal",
     launch_at_startup: false, animated_heroes: "animated", ui_scale: 1.0,
-    language: "auto",
+    language: "auto", time_format: "auto", show_date: true, show_battery: true, show_clock: true,
   });
   const [settingsFocusIndex, setSettingsFocusIndex] = useState(0);
   const [heroIndex, setHeroIndex]                   = useState(0);
@@ -1874,16 +1875,16 @@ export default function App() {
   useEffect(() => {
     const tick = () => {
       const now = new Date();
-      let h = now.getHours(), m = now.getMinutes();
-      const ampm = h >= 12 ? "PM" : "AM";
-      h = h % 12 || 12;
-      setTime(`${h}:${String(m).padStart(2, "0")} ${ampm}`);
-      setDate(now.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }));
+      const locale = i18n.language || "en";
+      const fmt = settingsRef.current.time_format;
+      const use12 = fmt === "12h" || (fmt === "auto" && new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions().hour12);
+      setTime(now.toLocaleTimeString(locale, { hour: "numeric", minute: "2-digit", hour12: use12 }));
+      setDate(now.toLocaleDateString(locale, { weekday: "short", month: "short", day: "numeric" }));
     };
     tick();
     const id = setInterval(tick, 10000);
     return () => clearInterval(id);
-  }, []);
+  }, [settings.time_format, i18n.language]);
 
   const getAudioCtx = () => {
     if (!audioCtxRef.current) audioCtxRef.current = new AudioContext();
@@ -1925,7 +1926,7 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    const fetchBattery = () => { invoke("get_battery").then(info => { if (info.percent > 0) setBattery(info.percent); setCharging(info.charging); }); };
+    const fetchBattery = () => { invoke("get_battery").then(info => { if (info.percent > 0) { setBattery(info.percent); setHasBattery(true); } setCharging(info.charging); }); };
     fetchBattery();
     const id = setInterval(fetchBattery, 10000);
     return () => clearInterval(id);
@@ -2277,6 +2278,10 @@ export default function App() {
     { key: "default_tab",       label: t('settings.defaultTab'),                            type: "cycle",  options: ["Home","Games","Apps"] },
     { key: "repeat_speed",      label: t('settings.repeatSpeed'),                           type: "cycle",  options: ["slow","normal","fast"] },
     { key: "language",          label: t('settings.language'),                               type: "cycle",  options: ["auto","en","fr"] },
+    { key: "time_format",       label: t('settings.timeFormat'),                             type: "cycle",  options: ["auto","12h","24h"] },
+    { key: "show_clock",        label: t('settings.showClock'),                              type: "toggle" },
+    { key: "show_date",         label: t('settings.showDate'),                               type: "toggle" },
+    { key: "show_battery",      label: t('settings.showBattery'),                            type: "toggle" },
     { key: "launch_at_startup", label: t('settings.launchAtStartup'),                       type: "toggle" },
     { key: "animated_heroes",   label: t('settings.heroArtMode'),                           type: "cycle",  options: ["static", "animated", "custom"] },
     { key: "divider_ctrl",      label: t('settings.dividers.controller'),                   type: "divider" },
@@ -3621,8 +3626,9 @@ export default function App() {
               ))}
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: 14, flexShrink: 0 }}>
-              <span style={{ fontSize: 12, color: theme.textDim }}>{date}</span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: isDark ? "rgba(245,237,232,0.7)" : "rgba(42,26,14,0.7)" }}>{time}</span>
+              {settings.show_date && <span style={{ fontSize: 12, color: theme.textDim }}>{date}</span>}
+              {settings.show_clock && <span style={{ fontSize: 13, fontWeight: 600, color: isDark ? "rgba(245,237,232,0.7)" : "rgba(42,26,14,0.7)" }}>{time}</span>}
+              {hasBattery && settings.show_battery && (
               <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
                 <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
                   <div style={{ width: 22, height: 11, border: `1.5px solid ${isDark ? "rgba(245,237,232,0.3)" : "rgba(42,26,14,0.3)"}`, borderRadius: 3, padding: "1.5px", display: "flex", alignItems: "center" }}>
@@ -3634,8 +3640,9 @@ export default function App() {
                     </svg>
                   )}
                 </div>
-                <span style={{ fontSize: 11, color: charging ? "#4ae88a" : theme.textDim }}>{battery > 0 ? `${battery}%` : "--"}</span>
+                <span style={{ fontSize: 11, color: charging ? "#4ae88a" : theme.textDim }}>{battery}%</span>
               </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 //Copyright (C) 2025 Taylor Denby
 
 import { useState, useEffect, useRef, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import i18n from "./i18n";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import uiSound from "./assets/uiSound.mp3";
@@ -205,6 +207,7 @@ const ss = {
 };
 
 function LaunchOverlay({ app, gameArt, customArt, accent, onDone }) {
+  const { t } = useTranslation();
   const art = app?.app_type === "game" ? (customArt?.[app?.id] || gameArt[app?.id]) : null;
   const [status, setStatus] = useState("launching"); // "launching" | "failed"
   const rafRef   = useRef(null);
@@ -291,14 +294,14 @@ function LaunchOverlay({ app, gameArt, customArt, accent, onDone }) {
         <div style={{ fontSize: 22, fontWeight: 700, color: "white", marginBottom: 8, letterSpacing: "0.02em" }}>{app?.name}</div>
         {status === "launching" ? (
           <div style={{ display: "flex", alignItems: "center", gap: 6, justifyContent: "center" }}>
-            <span style={{ fontSize: 13, color: "rgba(255,255,255,0.22)", letterSpacing: "0.1em", textTransform: "uppercase" }}>Launching</span>
+            <span style={{ fontSize: 13, color: "rgba(255,255,255,0.22)", letterSpacing: "0.1em", textTransform: "uppercase" }}>{t('launch.launching')}</span>
             <span style={{ display: "flex", gap: 3 }}>
               {[0,1,2].map(i => <span key={i} className="launch-dot" style={{ width: 4, height: 4, borderRadius: "50%", background: accent.primary, display: "inline-block" }} />)}
             </span>
           </div>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-            <div style={{ fontSize: 13, color: "rgba(255,90,90,0.95)", letterSpacing: "0.05em" }}>Failed to launch</div>
+            <div style={{ fontSize: 13, color: "rgba(255,90,90,0.95)", letterSpacing: "0.05em" }}>{t('launch.failed')}</div>
             <button
               onClick={onDone}
               style={{
@@ -310,7 +313,7 @@ function LaunchOverlay({ app, gameArt, customArt, accent, onDone }) {
                 letterSpacing: "0.06em",
               }}
             >
-              Dismiss  ·  B
+              {t('launch.dismiss')}
             </button>
           </div>
         )}
@@ -321,6 +324,7 @@ function LaunchOverlay({ app, gameArt, customArt, accent, onDone }) {
 
 // ── Custom Art Picker Modal ───────────────────────────────────
 function ArtPickerModal({ app, currentArt, hasCustomArt, cropMode = "portrait", accent, theme, isDark, glass, onClose, onSet, onReset }) {
+  const { t } = useTranslation();
   const fileRef = useRef(null);
   const [preview, setPreview] = useState(currentArt || null);
   const [pendingData, setPendingData] = useState(null);
@@ -442,26 +446,26 @@ function ArtPickerModal({ app, currentArt, hasCustomArt, cropMode = "portrait", 
     <div data-modal-overlay style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.78)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 300 }}>
       <div style={{ ...glass, borderRadius: 20, padding: 24, width: 380 }}>
         <div style={{ fontSize: 16, fontWeight: 700, color: theme.text, marginBottom: 4 }}>{app.name}</div>
-        <div style={{ fontSize: 12, color: theme.textDim, marginBottom: 16 }}>Replace cover art</div>
+        <div style={{ fontSize: 12, color: theme.textDim, marginBottom: 16 }}>{t('artPicker.replaceCoverArt')}</div>
         <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
           {/* Preview — fixed width, 2:3 tall */}
           <div style={{ flexShrink: 0, width: 110 }}>
             {preview
               ? <img src={preview} alt="" style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : "2/3", objectFit: "cover", borderRadius: 10, display: "block" }} />
-              : <div style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : "2/3", borderRadius: 10, background: `${accent.glow}0.1)`, display: "flex", alignItems: "center", justifyContent: "center" }}><span style={{ fontSize: 10, color: theme.textDim, textAlign: "center" }}>No art</span></div>
+              : <div style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : "2/3", borderRadius: 10, background: `${accent.glow}0.1)`, display: "flex", alignItems: "center", justifyContent: "center" }}><span style={{ fontSize: 10, color: theme.textDim, textAlign: "center" }}>{t('artPicker.noArt')}</span></div>
             }
           </div>
           {/* Controls */}
           <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 10 }}>
             <input ref={fileRef} type="file" accept="image/*" style={{ display: "none" }} onChange={handleFile} />
-            <button onClick={() => fileRef.current?.click()} style={btnStyle("browse", `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`, "white")}>Browse Image</button>
-            {pendingData && <button onClick={handleSave} disabled={saving} style={btnStyle("save", "#4a9c4a", "white", { opacity: saving ? 0.6 : 1 })}>{saving ? "Saving…" : "Save"}</button>}
-            {hasCustomArt && !pendingData && <button onClick={handleReset} style={btnStyle("reset", "rgba(255,255,255,0.08)", theme.text)}>Reset to Default</button>}
-            <button onClick={onClose} style={btnStyle("cancel", "rgba(255,255,255,0.05)", theme.textDim)}>Cancel</button>
+            <button onClick={() => fileRef.current?.click()} style={btnStyle("browse", `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`, "white")}>{t('artPicker.browseImage')}</button>
+            {pendingData && <button onClick={handleSave} disabled={saving} style={btnStyle("save", "#4a9c4a", "white", { opacity: saving ? 0.6 : 1 })}>{saving ? t('artPicker.saving') : t('common.save')}</button>}
+            {hasCustomArt && !pendingData && <button onClick={handleReset} style={btnStyle("reset", "rgba(255,255,255,0.08)", theme.text)}>{t('artPicker.resetToDefault')}</button>}
+            <button onClick={onClose} style={btnStyle("cancel", "rgba(255,255,255,0.05)", theme.textDim)}>{t('common.cancel')}</button>
             <div style={{ display: "flex", justifyContent: "center", gap: 12, paddingTop: 4 }}>
               {[
-                { bg: "#4a9c4a", label: "A Confirm" },
-                { bg: "#b03030", label: "B Cancel" },
+                { bg: "#4a9c4a", label: t('gamepad.aConfirm') },
+                { bg: "#b03030", label: t('gamepad.bCancel') },
               ].map(({ bg, label }) => (
                 <span key={label} style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                   <span style={{ width: 18, height: 18, borderRadius: "50%", background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: "white", flexShrink: 0 }}>{label[0]}</span>
@@ -481,6 +485,7 @@ function ArtPickerModal({ app, currentArt, hasCustomArt, cropMode = "portrait", 
 let _activeThumbVideo = null;
 
 function ThumbnailCard({ result, selected, isSelected, accent, theme, thumbW, aspect, onClick, ...rest }) {
+  const { t } = useTranslation();
   const [hovered, setHovered] = useState(false);
   const [videoSrc, setVideoSrc] = useState(null);
   const videoRef = useRef(null);
@@ -548,7 +553,7 @@ function ThumbnailCard({ result, selected, isSelected, accent, theme, thumbW, as
             display: "flex", alignItems: "center", justifyContent: "center",
           }}>
             <span style={{ fontSize: 11, color: "rgba(255,255,255,0.25)", fontWeight: 600, letterSpacing: "0.1em", textTransform: "uppercase" }}>
-              Hover to preview
+              {t('sgdb.hoverToPreview')}
             </span>
           </div>
         )
@@ -607,6 +612,7 @@ function ThumbnailCard({ result, selected, isSelected, accent, theme, thumbW, as
 const HERO_FILTERS = ["all", "animated", "static"];
 
 function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repeatSpeed = "normal" }) {
+  const { t } = useTranslation();
   const [results, setResults] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -763,10 +769,10 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
 
   if (error) return (
     <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12 }}>
-      <span style={{ color: theme.textDim, fontSize: 13 }}>Failed to load results</span>
+      <span style={{ color: theme.textDim, fontSize: 13 }}>{t('sgdb.failedToLoad')}</span>
       <button onClick={loadResults}
         style={{ padding: "8px 20px", borderRadius: 8, background: `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`, color: "white", fontWeight: 600, fontSize: 13, border: "none", cursor: "pointer" }}>
-        Retry
+        {t('common.retry')}
       </button>
     </div>
   );
@@ -781,7 +787,7 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
               style={{ padding: "4px 12px", borderRadius: 6, fontSize: 12, fontWeight: 600, cursor: "pointer", border: "none",
                 background: heroFilter === f ? accent.primary : (isDark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.1)"),
                 color: heroFilter === f ? "white" : theme.text }}>
-              {f.charAt(0).toUpperCase() + f.slice(1)}
+              {t(`sgdb.filter.${f}`)}
             </button>
           ))}
         </div>
@@ -797,14 +803,14 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
           ))}
           {filteredResults.length === 0 && (
             <div style={{ gridColumn: "1 / -1", textAlign: "center", color: theme.textDim, fontSize: 13, padding: 24 }}>
-              No results found
+              {t('sgdb.noResults')}
             </div>
           )}
         </div>
       </div>
       <div style={{ paddingTop: 10, display: "flex", alignItems: "center", gap: 10 }}>
         <div style={{ display: "flex", gap: 12, marginRight: "auto" }}>
-          {[{ bg: "#4a9c4a", label: "A Select" }, { bg: "#b03030", label: "B Cancel" }].map(({ bg, label }) => (
+          {[{ bg: "#4a9c4a", label: t('gamepad.aSelect') }, { bg: "#b03030", label: t('gamepad.bCancel') }].map(({ bg, label }) => (
             <span key={label} style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
               <span style={{ width: 18, height: 18, borderRadius: "50%", background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: "white", flexShrink: 0 }}>{label[0]}</span>
               {label.slice(1)}
@@ -814,14 +820,14 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
             <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
               <span style={{ height: 18, minWidth: 20, borderRadius: 4, background: "rgba(255,255,255,0.52)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: "white", padding: "0 3px" }}>LT</span>
               <span style={{ height: 18, minWidth: 20, borderRadius: 4, background: "rgba(255,255,255,0.52)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: "white", padding: "0 3px" }}>RT</span>
-              Filter
+              {t('sgdb.filter.label')}
             </span>
           )}
         </div>
         <button onClick={onClose}
           style={{ padding: "8px 16px", borderRadius: 8, fontSize: 13, fontWeight: 600, cursor: "pointer", border: "none",
             background: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)", color: theme.text }}>
-          Cancel
+          {t('common.cancel')}
         </button>
         <button onClick={handleSelect} disabled={selectedIdx === null || downloading}
           style={{ padding: "8px 20px", borderRadius: 8, fontSize: 13, fontWeight: 600,
@@ -830,7 +836,7 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
               ? `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`
               : (isDark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.1)"),
             color: selectedIdx !== null && !downloading ? "white" : theme.textDim, transition: "all 0.15s" }}>
-          {downloading ? "Downloading…" : "Select"}
+          {downloading ? t('sgdb.downloading') : t('common.select')}
         </button>
       </div>
     </div>
@@ -839,6 +845,7 @@ function SgdbBrowser({ app, artType, accent, theme, isDark, onSet, onClose, repe
 
 // ── UploadTab ─────────────────────────────────────────────────
 function UploadTab({ app, currentArt, hasCustomArt, cropMode = "portrait", accent, theme, isDark, onClose, onSet, onReset }) {
+  const { t } = useTranslation();
   const fileRef = useRef(null);
   const [preview, setPreview] = useState(currentArt || null);
   const [pendingData, setPendingData] = useState(null);
@@ -961,24 +968,24 @@ function UploadTab({ app, currentArt, hasCustomArt, cropMode = "portrait", accen
   return (
     <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
       <div style={{ width: 380 }}>
-        <div style={{ fontSize: 12, color: theme.textDim, marginBottom: 16 }}>Upload a custom image</div>
+        <div style={{ fontSize: 12, color: theme.textDim, marginBottom: 16 }}>{t('artPicker.uploadCustomImage')}</div>
         <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
           <div style={{ flexShrink: 0, width: cropMode === "hero" ? 220 : 110 }}>
             {preview
               ? <img src={preview} alt="" style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : cropMode === "hero" ? "1920/620" : "2/3", objectFit: "cover", borderRadius: 10, display: "block" }} />
-              : <div style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : cropMode === "hero" ? "1920/620" : "2/3", borderRadius: 10, background: `${accent.glow}0.1)`, display: "flex", alignItems: "center", justifyContent: "center" }}><span style={{ fontSize: 10, color: theme.textDim, textAlign: "center" }}>No art</span></div>
+              : <div style={{ width: "100%", aspectRatio: cropMode === "square" ? "1" : cropMode === "hero" ? "1920/620" : "2/3", borderRadius: 10, background: `${accent.glow}0.1)`, display: "flex", alignItems: "center", justifyContent: "center" }}><span style={{ fontSize: 10, color: theme.textDim, textAlign: "center" }}>{t('artPicker.noArt')}</span></div>
             }
           </div>
           <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 10 }}>
             <input ref={fileRef} type="file" accept="image/*" style={{ display: "none" }} onChange={handleFile} />
-            <button onClick={() => fileRef.current?.click()} style={btnStyle("browse", `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`, "white")}>Browse Image</button>
-            {pendingData && <button onClick={handleSave} disabled={saving} style={btnStyle("save", "#4a9c4a", "white", { opacity: saving ? 0.6 : 1 })}>{saving ? "Saving…" : "Save"}</button>}
-            {hasCustomArt && !pendingData && <button onClick={handleReset} style={btnStyle("reset", "rgba(255,255,255,0.08)", theme.text)}>Reset to Default</button>}
-            <button onClick={onClose} style={btnStyle("cancel", "rgba(255,255,255,0.05)", theme.textDim)}>Cancel</button>
+            <button onClick={() => fileRef.current?.click()} style={btnStyle("browse", `linear-gradient(135deg, ${accent.primary}, ${accent.dark})`, "white")}>{t('artPicker.browseImage')}</button>
+            {pendingData && <button onClick={handleSave} disabled={saving} style={btnStyle("save", "#4a9c4a", "white", { opacity: saving ? 0.6 : 1 })}>{saving ? t('artPicker.saving') : t('common.save')}</button>}
+            {hasCustomArt && !pendingData && <button onClick={handleReset} style={btnStyle("reset", "rgba(255,255,255,0.08)", theme.text)}>{t('artPicker.resetToDefault')}</button>}
+            <button onClick={onClose} style={btnStyle("cancel", "rgba(255,255,255,0.05)", theme.textDim)}>{t('common.cancel')}</button>
             <div style={{ display: "flex", justifyContent: "center", gap: 12, paddingTop: 4 }}>
               {[
-                { bg: "#4a9c4a", label: "A Confirm" },
-                { bg: "#b03030", label: "B Cancel" },
+                { bg: "#4a9c4a", label: t('gamepad.aConfirm') },
+                { bg: "#b03030", label: t('gamepad.bCancel') },
               ].map(({ bg, label }) => (
                 <span key={label} style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                   <span style={{ width: 18, height: 18, borderRadius: "50%", background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: "white", flexShrink: 0 }}>{label[0]}</span>
@@ -995,6 +1002,7 @@ function UploadTab({ app, currentArt, hasCustomArt, cropMode = "portrait", accen
 
 // ── SgdbBrowserModal ──────────────────────────────────────────
 function SgdbBrowserModal({ app, currentArt, hasCustomArt, cropMode = "portrait", artType = "grid", repeatSpeed = "normal", accent, theme, isDark, glass, onClose, onSet, onReset }) {
+  const { t } = useTranslation();
   const showSgdb = app?.app_type === "game";
   const [activeTab, setActiveTab] = useState(showSgdb ? "browse" : "upload");
   const lastBtnRef = useRef({});
@@ -1040,8 +1048,8 @@ function SgdbBrowserModal({ app, currentArt, hasCustomArt, cropMode = "portrait"
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 12, paddingBottom: 10,
           borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"}` }}>
           {showSgdb && <span style={badgeStyle}>LB</span>}
-          {showSgdb && <button onClick={() => setActiveTab("browse")} style={tabBtnStyle("browse")}>Browse SteamGridDB</button>}
-          <button onClick={() => setActiveTab("upload")} style={tabBtnStyle("upload")}>Upload File</button>
+          {showSgdb && <button onClick={() => setActiveTab("browse")} style={tabBtnStyle("browse")}>{t('artModal.browseSgdb')}</button>}
+          <button onClick={() => setActiveTab("upload")} style={tabBtnStyle("upload")}>{t('artModal.uploadFile')}</button>
           {showSgdb && <span style={badgeStyle}>RB</span>}
         </div>
         {showSgdb && activeTab === "browse"
@@ -1119,6 +1127,7 @@ let _cachedGpSnap = null;
 // Shows the controller name, mapping type, every button (lit when pressed),
 // and every axis as a bar — lets users identify index offsets on odd hardware.
 function ControllerTestWidget({ accent, theme, isDark, glass }) {
+  const { t } = useTranslation();
   const [gpSnap, setGpSnap] = useState(_cachedGpSnap);
   const rAFRef = useRef(null);
   useEffect(() => {
@@ -1142,7 +1151,7 @@ function ControllerTestWidget({ accent, theme, isDark, glass }) {
 
   if (!gpSnap) return (
     <div style={{ fontSize: 13, color: theme.textDim, padding: "4px 0 8px" }}>
-      No controller detected — connect a gamepad and press any button.
+      {t('settings.noController')}
     </div>
   );
 
@@ -1229,6 +1238,7 @@ function ControllerTestWidget({ accent, theme, isDark, glass }) {
 // Shows all apps (visible + hidden) in one list.
 // Checked = shown in launcher. Uncheck to hide, check to restore.
 function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggleHidden, glass, accent, isDark, theme }) {
+    const { t } = useTranslation();
     const visibleApps = appsRef.current.filter(a => tab === "Games" ? a.app_type === "game" : a.app_type === "app");
     const hiddenIds   = hiddenRef.current;
 
@@ -1371,17 +1381,17 @@ function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggle
           {/* Header */}
           <div style={{ padding: "20px 24px 14px", borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}`, flexShrink: 0 }}>
             <div style={{ fontSize: 16, fontWeight: 700, color: theme.text, marginBottom: 4 }}>
-              Manage {tab === "Games" ? "games" : "apps"}
+              {tab === "Games" ? t('hideModal.manageGames') : t('hideModal.manageApps')}
             </div>
             <div style={{ fontSize: 12, color: theme.textDim }}>
-              Checked = visible · Uncheck to hide · A to toggle · ↑↓ navigate · Menu to save · B to cancel
+              {t('hideModal.hint')}
             </div>
           </div>
 
           {/* List */}
           <div ref={listRef} style={{ overflowY: "auto", flex: 1, padding: "8px 0" }}>
             {allItems.length === 0 && (
-              <div style={{ padding: "40px 24px", textAlign: "center", color: theme.textFaint, fontSize: 13 }}>No apps found.</div>
+              <div style={{ padding: "40px 24px", textAlign: "center", color: theme.textFaint, fontSize: 13 }}>{t('hideModal.noApps')}</div>
             )}
             {allItems.map((item, i) => {
               const checked  = localChecked.has(item.id);
@@ -1429,7 +1439,7 @@ function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggle
                 background: focusIdx === cancelIdx ? (isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)") : (isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)"),
                 border: `2px solid ${focusIdx === cancelIdx ? accent.primary : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
                 transition: "all 0.1s ease" }}>
-              Cancel
+              {t('common.cancel')}
             </div>
             <div data-modal-row onClick={() => {
                 const checked = localChecked;
@@ -1443,7 +1453,7 @@ function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggle
                 border: `2px solid ${focusIdx === confirmIdx ? "white" : accent.primary}`,
                 boxShadow: `0 2px 12px ${accent.glow}0.4)`,
                 transition: "all 0.1s ease" }}>
-              {changeCount > 0 ? `Save ${changeCount} change${changeCount !== 1 ? "s" : ""}` : "Save"}
+              {changeCount > 0 ? t('hideModal.saveChanges', { count: changeCount }) : t('hideModal.save')}
             </div>
           </div>
         </div>
@@ -1477,6 +1487,7 @@ async function sampleIconColor(base64) {
 }
 
 export default function App() {
+  const { t } = useTranslation();
   const [tab, setTab]                               = useState("Home");
   const [apps, setApps]                             = useState([]);
   const [recent, setRecent]                         = useState([]);
@@ -1512,6 +1523,7 @@ export default function App() {
     default_tab: "Home", scan_steam: true, scan_xbox: true,
     scan_uwp: true, scan_desktop: true, scan_battlenet: true, repeat_speed: "normal",
     launch_at_startup: false, animated_heroes: "animated", ui_scale: 1.0,
+    language: "auto",
   });
   const [settingsFocusIndex, setSettingsFocusIndex] = useState(0);
   const [heroIndex, setHeroIndex]                   = useState(0);
@@ -1929,10 +1941,12 @@ export default function App() {
       const updated = { ...s, ui_scale: s.ui_scale ?? auto };
       setSettings(updated); settingsRef.current = updated;
       setTab(s.default_tab || "Home"); tabRef.current = s.default_tab || "Home";
+      if (s.language && s.language !== "auto") i18n.changeLanguage(s.language);
     }).catch(() => {
       invoke("get_settings").then(s => {
         setSettings(s); settingsRef.current = s;
         setTab(s.default_tab || "Home"); tabRef.current = s.default_tab || "Home";
+        if (s.language && s.language !== "auto") i18n.changeLanguage(s.language);
       });
     });
     invoke("get_custom_art").then(art => {
@@ -2031,13 +2045,13 @@ export default function App() {
 
   const handleClearCache = async () => {
     setCacheClearLoading(true);
-    setCacheClearStatus({ line1: "Clearing Cache", line2: "Removing cached artwork files…" });
+    setCacheClearStatus({ line1: t('cache.clearing'), line2: t('cache.removingFiles') });
     await invoke("clear_art_cache");
     setGameArt({}); setHeroAnimated({}); setHeroStatic({});
     const games = appsRef.current.filter(a => a.app_type === "game");
-    setCacheClearStatus({ line1: "Downloading Artwork", line2: `Starting download for ${games.length} games…` });
+    setCacheClearStatus({ line1: t('cache.downloadingArtwork'), line2: t('cache.startingDownload', { count: games.length }) });
     await fetchGameArt(games, (done, total, lastName) => {
-      setCacheClearStatus({ line1: "Downloading Artwork", line2: `${lastName ? `${lastName} — ` : ""}${done} / ${total} games` });
+      setCacheClearStatus({ line1: t('cache.downloadingArtwork'), line2: t('cache.progress', { name: lastName ? `${lastName} — ` : "", done, total }) });
     });
     setCacheClearLoading(false);
   };
@@ -2052,6 +2066,14 @@ export default function App() {
       return updated;
     });
     if (SCAN_KEYS.includes(key)) setTimeout(refreshLibrary, 50);
+    if (key === "language") {
+      if (value === "auto") {
+        const detected = navigator.language?.split("-")[0] || "en";
+        i18n.changeLanguage(detected);
+      } else {
+        i18n.changeLanguage(value);
+      }
+    }
   };
 
   const checkForUpdates = () => {
@@ -2238,36 +2260,37 @@ export default function App() {
   };
 
   const SETTINGS_ITEMS = [
-    { key: "accent",            label: "Accent Color",           type: "accent" },
-    { key: "theme",             label: "Theme",                  type: "cycle",  options: ["dark","light","system"] },
-    { key: "stars_enabled",     label: isDark ? "Background Stars" : "Background Clouds", type: "toggle" },
-    { key: "divider_display",   label: "DISPLAY",                type: "divider" },
-    { key: "ui_scale",          label: "UI Scale",               type: "slider", min: 0.75, max: 2.0, step: 0.05 },
-    { key: "reset_scale",       label: "Reset Scale to Auto",    type: "action" },
-    { key: "divider",           label: "LIBRARY",                type: "divider" },
-    { key: "scan_steam",        label: "Scan Steam",             type: "toggle" },
-    { key: "scan_xbox",         label: "Scan Xbox",              type: "toggle" },
-    { key: "scan_uwp",          label: "Scan Store Apps",        type: "toggle" },
-    { key: "scan_desktop",      label: "Scan Desktop Shortcuts", type: "toggle" },
-    { key: "scan_battlenet",    label: "Scan Battle.net",        type: "toggle" },
-    { key: "refresh_library",   label: "Refresh Library",        type: "refresh" },
-    { key: "divider2",          label: "BEHAVIOR",               type: "divider" },
-    { key: "default_tab",       label: "Default Tab",            type: "cycle",  options: ["Home","Games","Apps"] },
-    { key: "repeat_speed",      label: "Stick Repeat Speed",     type: "cycle",  options: ["slow","normal","fast"] },
-    { key: "launch_at_startup", label: "Launch at Startup",      type: "toggle" },
-    { key: "animated_heroes",   label: "Hero Art Mode",          type: "cycle",  options: ["static", "animated", "custom"] },
-    { key: "divider_ctrl",      label: "CONTROLLER",             type: "divider" },
-    { key: "controller_test",   label: "Controller Test",        type: "controller_test" },
-    { key: "divider3",          label: "DATA",                   type: "divider" },
-    { key: "clear_recents",     label: "Clear Recently Played",  type: "action" },
-    { key: "clear_cache",       label: "Clear Art Cache",        type: "action" },
-    { key: "divider4",          label: "ABOUT",                  type: "divider" },
-    { key: "version",           label: `LiftOff v${APP_VERSION}`, type: "info" },
-    { key: "check_updates",     label: "Check for Updates",       type: "update" },
-    { key: "coffee",            label: "☕ Buy Me a Coffee",      type: "link" },
-    { key: "github",            label: "⭐ GitHub",               type: "link" },
-    { key: "discord",           label: "💬 Discord",              type: "link" },
-    { key: "divider5",  label: "CREDITS",                         type: "divider" },
+    { key: "accent",            label: t('settings.accentColor'),                           type: "accent" },
+    { key: "theme",             label: t('settings.theme'),                                 type: "cycle",  options: ["dark","light","system"] },
+    { key: "stars_enabled",     label: isDark ? t('settings.backgroundStars') : t('settings.backgroundClouds'), type: "toggle" },
+    { key: "divider_display",   label: t('settings.dividers.display'),                      type: "divider" },
+    { key: "ui_scale",          label: t('settings.uiScale'),                               type: "slider", min: 0.75, max: 2.0, step: 0.05 },
+    { key: "reset_scale",       label: t('settings.resetScale'),                            type: "action" },
+    { key: "divider",           label: t('settings.dividers.library'),                      type: "divider" },
+    { key: "scan_steam",        label: t('settings.scanSteam'),                             type: "toggle" },
+    { key: "scan_xbox",         label: t('settings.scanXbox'),                              type: "toggle" },
+    { key: "scan_uwp",          label: t('settings.scanStoreApps'),                         type: "toggle" },
+    { key: "scan_desktop",      label: t('settings.scanDesktop'),                           type: "toggle" },
+    { key: "scan_battlenet",    label: t('settings.scanBattlenet'),                         type: "toggle" },
+    { key: "refresh_library",   label: t('settings.refreshLibrary'),                        type: "refresh" },
+    { key: "divider2",          label: t('settings.dividers.behavior'),                     type: "divider" },
+    { key: "default_tab",       label: t('settings.defaultTab'),                            type: "cycle",  options: ["Home","Games","Apps"] },
+    { key: "repeat_speed",      label: t('settings.repeatSpeed'),                           type: "cycle",  options: ["slow","normal","fast"] },
+    { key: "language",          label: t('settings.language'),                               type: "cycle",  options: ["auto","en","fr"] },
+    { key: "launch_at_startup", label: t('settings.launchAtStartup'),                       type: "toggle" },
+    { key: "animated_heroes",   label: t('settings.heroArtMode'),                           type: "cycle",  options: ["static", "animated", "custom"] },
+    { key: "divider_ctrl",      label: t('settings.dividers.controller'),                   type: "divider" },
+    { key: "controller_test",   label: t('settings.controllerTest'),                        type: "controller_test" },
+    { key: "divider3",          label: t('settings.dividers.data'),                         type: "divider" },
+    { key: "clear_recents",     label: t('settings.clearRecents'),                          type: "action" },
+    { key: "clear_cache",       label: t('settings.clearCache'),                            type: "action" },
+    { key: "divider4",          label: t('settings.dividers.about'),                        type: "divider" },
+    { key: "version",           label: t('settings.version', { version: APP_VERSION }),     type: "info" },
+    { key: "check_updates",     label: t('settings.checkUpdates'),                          type: "update" },
+    { key: "coffee",            label: t('settings.coffee'),                                type: "link" },
+    { key: "github",            label: t('settings.github'),                                type: "link" },
+    { key: "discord",           label: t('settings.discord'),                               type: "link" },
+    { key: "divider5",  label: t('settings.dividers.credits'),                              type: "divider" },
     { key: "credit1",   label: "Mysterious Magical Bell Flourish", author: "DanaiOuranos", license: "CC0",       url: "https://freesound.org/s/848847/",                        type: "attribution" },
     { key: "credit2",   label: "Achievement Sparkle",              author: "DanaiOuranos", license: "CC0",       url: "https://freesound.org/s/715067/",                        type: "attribution" },
     { key: "credit3",   label: "Mysterious Sparkle Flourish",      author: "DanaiOuranos", license: "CC0",       url: "https://freesound.org/s/844398/",                        type: "attribution" },
@@ -2290,10 +2313,10 @@ export default function App() {
     if (contextMenuRef.current) {
       const menu = contextMenuRef.current;
       const menuItems = [
-        { label: "Open" },
-        { label: menu.app.app_type === "game" ? (pins.includes(menu.app.id) ? "Unpin" : "Pin") : (pins.includes(menu.app.id) ? "Unpin" : "Pin") },
-        { label: "Change Art" },
-        ...(menu.app.app_type === "game" ? [{ label: "Change Hero Art" }] : []),
+        { key: "open" },
+        { key: pins.includes(menu.app.id) ? "unpin" : "pin" },
+        { key: "changeArt" },
+        ...(menu.app.app_type === "game" ? [{ key: "changeHeroArt" }] : []),
       ];
       const cur = menu.focusedIdx || 0;
       if (key === "ArrowDown") {
@@ -2309,11 +2332,11 @@ export default function App() {
         return;
       }
       if (key === "Enter") {
-        const label = menuItems[cur]?.label;
-        if (label === "Open") { triggerLaunch(menu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; }
-        else if (label === "Pin" || label === "Unpin") { togglePin(menu.app); setContextMenu(null); contextMenuRef.current = null; }
-        else if (label === "Change Art") { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
-        else if (label === "Change Hero Art") { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
+        const itemKey = menuItems[cur]?.key;
+        if (itemKey === "open") { triggerLaunch(menu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; }
+        else if (itemKey === "pin" || itemKey === "unpin") { togglePin(menu.app); setContextMenu(null); contextMenuRef.current = null; }
+        else if (itemKey === "changeArt") { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
+        else if (itemKey === "changeHeroArt") { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
         return;
       }
       if (key === "Escape" || key === "BumperLeft" || key === "BumperRight") {
@@ -2821,7 +2844,7 @@ export default function App() {
           <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.15em", textTransform: "uppercase",
             color: accent.primary, background: `${accent.glow}0.12)`, borderRadius: 20,
             padding: "3px 14px", border: `1px solid ${accent.glow}0.25)` }}>
-            {kbNumMode ? "Numbers & Symbols" : "Letters"}
+            {kbNumMode ? t('keyboard.numbersAndSymbols') : t('keyboard.letters')}
           </div>
         </div>
         {layout.map((row, rIdx) => (
@@ -2856,12 +2879,12 @@ export default function App() {
         <div style={{ display: "flex", justifyContent: "center", gap: 10, marginTop: 8, paddingTop: 8,
           borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}` }}>
           {[
-            { bg: "#4a9c4a", label: "A",  desc: "Type",       circle: true },
-            { bg: "#3a5a8a", label: "X",  desc: "Delete",     circle: true },
-            { bg: "#9a7020", label: "Y",  desc: "Space",      circle: true },
-            { bg: "#b03030", label: "B",  desc: "Results",    circle: true },
+            { bg: "#4a9c4a", label: "A",  desc: t('keyboard.type'),    circle: true },
+            { bg: "#3a5a8a", label: "X",  desc: t('keyboard.delete'),  circle: true },
+            { bg: "#9a7020", label: "Y",  desc: t('keyboard.space'),   circle: true },
+            { bg: "#b03030", label: "B",  desc: t('keyboard.results'), circle: true },
             { bg: isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.18)", label: "RT", desc: kbNumMode ? "→ ABC" : "→ 123", circle: false },
-            { bg: isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.18)", label: "⊞",  desc: "Results",    circle: false },
+            { bg: isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.18)", label: "⊞",  desc: t('keyboard.results'), circle: false },
           ].map(({ bg, label, desc, circle }) => (
             <div key={label} style={{ display: "flex", alignItems: "center", gap: 4 }}>
               <div style={{ width: circle ? 18 : "auto", height: 18, minWidth: 18, borderRadius: circle ? "50%" : 4,
@@ -3000,7 +3023,7 @@ export default function App() {
                 })}
               </div>
             ) : (
-              <div style={{ fontSize: 10, color: "rgba(245,237,232,0.25)", letterSpacing: "0.1em" }}>Pin apps with X to show them here</div>
+              <div style={{ fontSize: 10, color: "rgba(245,237,232,0.25)", letterSpacing: "0.1em" }}>{t('home.pinHint')}</div>
             )}
           </div>
 
@@ -3017,10 +3040,10 @@ export default function App() {
             {heroGame ? (
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ fontSize: 10, letterSpacing: "0.2em", textTransform: "uppercase", color: accent.primary, marginBottom: 6, fontWeight: 600 }}>
-                  {heroIdx === 0 ? "▶ Resume playing" : "▶ Recently played"}
+                  {heroIdx === 0 ? t('home.resumePlaying') : t('home.recentlyPlayed')}
                 </div>
                 <div style={{ fontSize: "clamp(22px, 3.2vw, 48px)", fontWeight: 700, color: theme.text, marginBottom: 4, lineHeight: 1.05, textShadow: isDark ? "0 2px 20px rgba(0,0,0,0.8)" : "none" }}>{heroGame.name}</div>
-                <div style={{ fontSize: 11, color: theme.textDim, marginBottom: 16 }}>Game</div>
+                <div style={{ fontSize: 11, color: theme.textDim, marginBottom: 16 }}>{t('home.game')}</div>
                 <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
                   <div onClick={() => triggerLaunch(heroGame, recentRef.current)}
                     style={{ display: "inline-flex", alignItems: "center", gap: 8, padding: "10px 24px", borderRadius: 10, cursor: "pointer", transition: "all 0.15s ease", fontWeight: 600, fontSize: 14,
@@ -3031,7 +3054,7 @@ export default function App() {
                       boxShadow: heroFocused ? `0 4px 24px ${accent.glow}0.5)` : "none",
                     }}>
                     <svg width="11" height="11" viewBox="0 0 10 10" fill="currentColor"><path d="M2 1.5l7 3.5-7 3.5z"/></svg>
-                    Launch
+                    {t('home.launch')}
                   </div>
                   {recentGames.length > 1 && (
                     <div style={{ display: "flex", gap: 5, alignItems: "center" }}>
@@ -3045,7 +3068,7 @@ export default function App() {
                 </div>
               </div>
             ) : (
-              <div style={{ fontSize: 14, color: theme.textFaint }}>Launch a game to see it here</div>
+              <div style={{ fontSize: 14, color: theme.textFaint }}>{t('home.noGames')}</div>
             )}
           </div>
           {heroFocused && <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: 3, background: `linear-gradient(to right, ${accent.primary}, ${accent.glow}0))`, pointerEvents: "none", zIndex: 3 }} />}
@@ -3055,7 +3078,7 @@ export default function App() {
         <div style={{ paddingTop: 0 }}>
           <div style={{ paddingTop: 14 }} />
           {homeFilteredRecent.length === 0 ? (
-            <div style={{ fontSize: 13, color: theme.textFaint, paddingBottom: 100 }}>Nothing here yet — launch something!</div>
+            <div style={{ fontSize: 13, color: theme.textFaint, paddingBottom: 100 }}>{t('home.noRecents')}</div>
           ) : (
             <div style={{ display: "flex", gap: 10, overflowX: "auto", paddingBottom: 100, paddingTop: 8, marginTop: -8, paddingLeft: 6, paddingRight: 6 }}>
               {homeFilteredRecent.map((app, i) => {
@@ -3186,7 +3209,7 @@ export default function App() {
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                 <span style={{ fontSize: 10, color: theme.textDim, cursor: "pointer", userSelect: "none" }}
                   onClick={() => updateSetting(item.key, opts[(cur - 1 + opts.length) % opts.length])}>◀</span>
-                <span style={{ fontSize: 12, color: accent.primary, fontWeight: 600, textTransform: "capitalize" }}>{settings[item.key]}</span>
+                <span style={{ fontSize: 12, color: accent.primary, fontWeight: 600 }}>{t(`settings.values.${settings[item.key]}`, settings[item.key])}</span>
                 <span style={{ fontSize: 10, color: theme.textDim, cursor: "pointer", userSelect: "none" }}
                   onClick={() => updateSetting(item.key, opts[(cur + 1) % opts.length])}>▶</span>
               </div>
@@ -3213,9 +3236,9 @@ export default function App() {
           );
         }
         if (item.type === "refresh") {
-          const statusText  = libraryRefreshStatus === "scanning" ? "Scanning..."
-                            : libraryRefreshStatus === "done"     ? "✓ Done"
-                            : "↵ Refresh";
+          const statusText  = libraryRefreshStatus === "scanning" ? t('settings.status.scanning')
+                            : libraryRefreshStatus === "done"     ? t('settings.status.done')
+                            : t('settings.status.refresh');
           const statusColor = libraryRefreshStatus === "done" ? "#4ae88a"
                             : theme.textDim;
           return (
@@ -3282,15 +3305,15 @@ export default function App() {
             if (item.key === "reset_scale")   updateSetting("ui_scale", autoScaleRef.current);
           }}>
             <span style={{ fontSize: 14, fontWeight: 500, color: item.key === "reset_scale" ? theme.text : "#e84a4a" }}>{item.label}</span>
-            <span style={{ fontSize: 12, color: theme.textDim }}>{item.key === "reset_scale" ? "↵ Apply" : "↵ Confirm"}</span>
+            <span style={{ fontSize: 12, color: theme.textDim }}>{item.key === "reset_scale" ? t('settings.status.apply') : t('settings.status.confirm')}</span>
           </div>
         );
         if (item.type === "update") {
-          const statusText = updateStatus === "checking"   ? "Checking..."
-                           : updateStatus === "up_to_date" ? "✓ Up to date"
-                           : updateStatus === "available"  ? `↓ v${updateInfo} available`
-                           : updateStatus === "error"      ? "⚠ Check failed"
-                           : "↵ Check";
+          const statusText = updateStatus === "checking"   ? t('settings.status.checking')
+                           : updateStatus === "up_to_date" ? t('settings.status.upToDate')
+                           : updateStatus === "available"  ? t('settings.status.updateAvailable', { version: updateInfo })
+                           : updateStatus === "error"      ? t('settings.status.checkFailed')
+                           : t('settings.status.check');
           const statusColor = updateStatus === "up_to_date" ? "#4ae88a"
                             : updateStatus === "available"  ? accent.primary
                             : updateStatus === "error"      ? "#e84a4a"
@@ -3308,16 +3331,16 @@ export default function App() {
         if (item.type === "link") return (
           <div key={item.key} ref={rowRef} style={rowStyle}>
             <span style={{ fontSize: 14, fontWeight: 500, color: theme.text }}>{item.label}</span>
-            <span style={{ fontSize: 12, color: theme.textDim }}>↵ Open</span>
+            <span style={{ fontSize: 12, color: theme.textDim }}>{t('settings.status.open')}</span>
           </div>
         );
         if (item.type === "attribution") return (
           <div key={item.key} ref={rowRef} style={rowStyle}>
             <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
               <span style={{ fontSize: 13, fontWeight: 500, color: theme.text }}>{item.label}</span>
-              <span style={{ fontSize: 11, color: theme.textDim }}>by {item.author} · {item.license}</span>
+              <span style={{ fontSize: 11, color: theme.textDim }}>{t('settings.attribution', { author: item.author, license: item.license })}</span>
             </div>
-            <span style={{ fontSize: 12, color: theme.textDim }}>↵ Open</span>
+            <span style={{ fontSize: 12, color: theme.textDim }}>{t('settings.status.open')}</span>
           </div>
         );
         if (item.type === "controller_test") return (
@@ -3419,8 +3442,8 @@ export default function App() {
             <div className="splash-dots" style={{ opacity: 1 }}>
               <div className="splash-dot" /><div className="splash-dot" /><div className="splash-dot" />
             </div>
-            <span style={{ fontSize: 15, fontWeight: 600, color: theme.text }}>Refreshing library…</span>
-            <span style={{ fontSize: 12, color: theme.textDim }}>Scanning for apps and games</span>
+            <span style={{ fontSize: 15, fontWeight: 600, color: theme.text }}>{t('library.refreshing')}</span>
+            <span style={{ fontSize: 12, color: theme.textDim }}>{t('library.scanning')}</span>
           </div>
         </div>
       )}
@@ -3447,7 +3470,7 @@ export default function App() {
               <div style={{ flex: 1, fontSize: 20, fontWeight: 500, minWidth: 0, overflow: "hidden",
                 whiteSpace: "nowrap", textOverflow: "ellipsis",
                 color: searchQuery ? theme.text : theme.textFaint }}>
-                {searchQuery || "Search games & apps…"}
+                {searchQuery || t('search.placeholder')}
                 {searchMode === "keyboard" && (
                   <span className="kb-cursor" style={{ display: "inline-block", width: 2, height: "0.9em",
                     background: accent.primary, marginLeft: 1, verticalAlign: "text-bottom", borderRadius: 1 }} />
@@ -3457,19 +3480,19 @@ export default function App() {
                 <div onClick={() => { setSearchQuery(""); searchQueryRef.current = ""; setSearchFocusIndex(0); searchFocusIndexRef.current = 0; }}
                   style={{ fontSize: 12, color: theme.textDim, cursor: "pointer", padding: "3px 10px", borderRadius: 6, flexShrink: 0,
                     background: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)" }}>
-                  Clear
+                  {t('common.clear')}
                 </div>
               )}
               <div style={{ fontSize: 11, fontWeight: 600, color: accent.primary, padding: "3px 10px",
                 borderRadius: 20, flexShrink: 0, background: `${accent.glow}0.12)`,
                 border: `1px solid ${accent.glow}0.25)` }}>
-                {searchMode === "keyboard" ? "Typing" : searchMode === "results" ? "Browsing" : "Idle"}
+                {searchMode === "keyboard" ? t('search.mode.typing') : searchMode === "results" ? t('search.mode.browsing') : t('search.mode.idle')}
               </div>
               <div onClick={closeSearch}
                 style={{ fontSize: 12, color: theme.textDim, cursor: "pointer", padding: "3px 10px", borderRadius: 6, flexShrink: 0,
                   background: isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
                   border: `1px solid ${isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)"}` }}>
-                Close
+                {t('common.close')}
               </div>
             </div>
           </div>
@@ -3480,15 +3503,15 @@ export default function App() {
               <>
                 <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase",
                   color: theme.textFaint, padding: "4px 4px 10px", display: "flex", alignItems: "center", gap: 10 }}>
-                  <span>{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}</span>
+                  <span>{t('search.results', { count: searchResults.length })}</span>
                   {searchMode === "keyboard" && (
                     <span style={{ fontWeight: 400, letterSpacing: 0, textTransform: "none", fontSize: 11, color: theme.textFaint }}>
-                      — <strong style={{ color: theme.textDim }}>⊞ Start</strong> to browse
+                      {t('search.startToBrowse')}
                     </span>
                   )}
                   {searchMode === "idle" && (
                     <span style={{ fontWeight: 400, letterSpacing: 0, textTransform: "none", fontSize: 11, color: theme.textFaint }}>
-                      — <strong style={{ color: theme.textDim }}>Y</strong> to type · <strong style={{ color: theme.textDim }}>⊞</strong> to browse
+                      {t('search.idleHint')}
                     </span>
                   )}
                 </div>
@@ -3550,9 +3573,9 @@ export default function App() {
             {searchMode === "results" && (
               <div style={{ position: "sticky", bottom: 0, paddingTop: 8 }}>
                 <div style={{ ...glass, borderRadius: 12, padding: "9px 20px", display: "flex", gap: 16, alignItems: "center" }}>
-                  <Btn color="#4a9c4a" label="A Launch" />
-                  <Btn color="#9a7020" label="Y Keyboard" />
-                  <Btn color="#b03030" label="B Close" />
+                  <Btn color="#4a9c4a" label={t('gamepad.aLaunch')} />
+                  <Btn color="#9a7020" label={t('gamepad.yKeyboard')} />
+                  <Btn color="#b03030" label={t('gamepad.bClose')} />
                   <span style={{ marginLeft: "auto", fontSize: 11, color: theme.textFaint }}>↑ from top → Keyboard</span>
                 </div>
               </div>
@@ -3561,9 +3584,9 @@ export default function App() {
             {searchMode === "idle" && (
               <div style={{ position: "sticky", bottom: 0, paddingTop: 8 }}>
                 <div style={{ ...glass, borderRadius: 12, padding: "9px 20px", display: "flex", gap: 16, alignItems: "center" }}>
-                  <Btn color="#9a7020" label="Y Keyboard" />
-                  <Btn color="#b03030" label="B Close" />
-                  {searchResults.length > 0 && <span style={{ fontSize: 11, color: theme.textFaint }}>⊞ Start → Browse</span>}
+                  <Btn color="#9a7020" label={t('gamepad.yKeyboard')} />
+                  <Btn color="#b03030" label={t('gamepad.bClose')} />
+                  {searchResults.length > 0 && <span style={{ fontSize: 11, color: theme.textFaint }}>{t('search.startBrowse')}</span>}
                 </div>
               </div>
             )}
@@ -3588,13 +3611,13 @@ export default function App() {
               <span key={`${settings.accent}-${settings.theme}`} style={{ fontWeight: 700, fontSize: 16, letterSpacing: "0.04em", background: `linear-gradient(135deg, ${accent.light}, ${accent.primary})`, WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent", backgroundClip: "text" }}>LiftOff</span>
             </div>
             <div style={{ display: "flex", gap: 2, flex: 1, justifyContent: "center" }}>
-              {TABS.map((t) => (
-                <div key={t} onClick={() => switchTab(t)} style={{
+              {TABS.map((tabName) => (
+                <div key={tabName} onClick={() => switchTab(tabName)} style={{
                   fontSize: 11, fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase",
-                  color: tab === t ? theme.text : theme.textDim, padding: "6px 16px", borderRadius: 8, cursor: "pointer",
-                  border: `1px solid ${tab === t ? `${accent.glow}0.35)` : "transparent"}`,
-                  background: tab === t ? `${accent.glow}0.15)` : "transparent",
-                }}>{t}</div>
+                  color: tab === tabName ? theme.text : theme.textDim, padding: "6px 16px", borderRadius: 8, cursor: "pointer",
+                  border: `1px solid ${tab === tabName ? `${accent.glow}0.35)` : "transparent"}`,
+                  background: tab === tabName ? `${accent.glow}0.15)` : "transparent",
+                }}>{t(`tabs.${tabName.toLowerCase()}`)}</div>
               ))}
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: 14, flexShrink: 0 }}>
@@ -3660,7 +3683,7 @@ export default function App() {
                               border: `1px solid ${active ? accent.primary : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
                               boxShadow: active ? `0 2px 10px ${accent.glow}0.35)` : "none",
                             }}>
-                            {src}
+                            {src === "All" ? t('sources.all') : src === "Other" ? t('sources.other') : src}
                           </div>
                         );
                       })}
@@ -3673,7 +3696,7 @@ export default function App() {
                       color: theme.textDim, background: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)",
                       border: `1px solid ${isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)"}`,
                     }}>
-                    Manage
+                    {t('grid.manage')}
                   </div>
                 </div>
               );
@@ -3683,8 +3706,8 @@ export default function App() {
             {pinnedAppsReactive.length > 0 && !(tab === "Games" && gameSourceTab !== "All") && (
               <>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "18px 0 10px" }}>
-                  <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: theme.textFaint }}>Pinned</div>
-                  <div style={{ fontSize: 10, color: theme.textFaint, opacity: 0.6 }}>X to unpin</div>
+                  <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: "0.2em", textTransform: "uppercase", color: theme.textFaint }}>{t('grid.pinned')}</div>
+                  <div style={{ fontSize: 10, color: theme.textFaint, opacity: 0.6 }}>{t('grid.unpinHint')}</div>
                 </div>
                 {tab === "Games" ? (
                   <div style={{ display: "grid", gridTemplateColumns: "repeat(5, minmax(0, 1fr))", gap: 12, paddingTop: 6, marginTop: -6, paddingBottom: 14 }}>
@@ -3811,40 +3834,40 @@ export default function App() {
         <div style={{ position: "sticky", bottom: 0, zIndex: 100 }}>
           <div style={{ ...glass, borderRadius: 12, padding: "10px 20px", display: "flex", gap: 20, alignItems: "center", maxWidth: 1400, margin: "0 auto 14px", width: "calc(100% - 48px)" }}>
             {tab === "Settings"
-              ? <><Btn color="#4a9c4a" label="A Select" /><Btn color="#b03030" label="B Back" /></>
+              ? <><Btn color="#4a9c4a" label={t('gamepad.aSelect')} /><Btn color="#b03030" label={t('gamepad.bBack')} /></>
               : <>
-                  <Btn color="#4a9c4a" label="A Launch" />
-                  <Btn color="#b03030" label="B Back" />
-                  <Btn color="#9a7020" label="Y Search" />
-                  <Btn color="#3a5a8a" label="X Pin" />
+                  <Btn color="#4a9c4a" label={t('gamepad.aLaunch')} />
+                  <Btn color="#b03030" label={t('gamepad.bBack')} />
+                  <Btn color="#9a7020" label={t('gamepad.ySearch')} />
+                  <Btn color="#3a5a8a" label={t('gamepad.xPin')} />
                   <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                     <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>LB</span>
                     <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>RB</span>
-                    Tabs
+                    {t('gamepad.tabs')}
                   </span>
                   {tab === "Games" && <>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                       <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>LT</span>
                       <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>RT</span>
-                      Source
+                      {t('gamepad.source')}
                     </span>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                       <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>MENU</span>
-                      Options
+                      {t('gamepad.options')}
                     </span>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                       <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>BACK</span>
-                      Manage
+                      {t('grid.manage')}
                     </span>
                   </>}
                   {tab === "Apps" && <>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                       <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>MENU</span>
-                      Options
+                      {t('gamepad.options')}
                     </span>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
                       <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>BACK</span>
-                      Manage
+                      {t('grid.manage')}
                     </span>
                   </>}
                 </>
@@ -3855,11 +3878,11 @@ export default function App() {
 
       {contextMenu && (() => {
         const ctxItems = [
-          { label: "Open", action: () => { triggerLaunch(contextMenu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; } },
-          { label: pins.includes(contextMenu.app.id) ? "Unpin" : "Pin", action: () => { togglePin(contextMenu.app); setContextMenu(null); contextMenuRef.current = null; } },
-          { label: "Change Art", action: () => { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } },
+          { label: t('contextMenu.open'),      action: () => { triggerLaunch(contextMenu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; } },
+          { label: t(pins.includes(contextMenu.app.id) ? 'contextMenu.unpin' : 'contextMenu.pin'), action: () => { togglePin(contextMenu.app); setContextMenu(null); contextMenuRef.current = null; } },
+          { label: t('contextMenu.changeArt'), action: () => { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } },
           ...(contextMenu.app.app_type === "game"
-            ? [{ label: "Change Hero Art", action: () => { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } }]
+            ? [{ label: t('contextMenu.changeHeroArt'), action: () => { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } }]
             : []),
         ];
         const ctxFocused = contextMenu.focusedIdx || 0;
@@ -3891,7 +3914,7 @@ export default function App() {
                 ))}
               </div>
               <div style={{ padding: "6px 16px 8px", borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)"}`, display: "flex", gap: 10 }}>
-                {[{ bg: "#4a9c4a", label: "A Select" }, { bg: "#b03030", label: "B Close" }].map(({ bg, label }) => (
+                {[{ bg: "#4a9c4a", label: t('gamepad.aSelect') }, { bg: "#b03030", label: t('gamepad.bClose') }].map(({ bg, label }) => (
                   <span key={label} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 10, color: theme.textDim }}>
                     <span style={{ width: 16, height: 16, borderRadius: "50%", background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: "white", flexShrink: 0 }}>{label[0]}</span>
                     {label.slice(1)}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,29 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import en from "./locales/en.json";
+import fr from "./locales/fr.json";
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
+    },
+    fallbackLng: "en",
+    supportedLngs: ["en", "fr"],
+    // navigator.language in Tauri's WebView reflects the OS locale.
+    // No localStorage caching — Tauri settings is the single source of truth
+    // for explicit language preferences; "auto" falls back to navigator.
+    detection: {
+      order: ["navigator"],
+      cacheUserLanguage: false,
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,6 +69,10 @@
     "clearRecents": "Clear Recently Played",
     "clearCache": "Clear Art Cache",
     "language": "Language",
+    "timeFormat": "Time Format",
+    "showClock": "Show Clock",
+    "showDate": "Show Date",
+    "showBattery": "Show Battery",
     "version": "LiftOff v{{version}}",
     "checkUpdates": "Check for Updates",
     "coffee": "☕ Buy Me a Coffee",
@@ -112,7 +116,9 @@
       "Apps": "Apps",
       "auto": "Auto",
       "en": "English",
-      "fr": "Français"
+      "fr": "Français",
+      "12h": "12h",
+      "24h": "24h"
     }
   },
   "home": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,194 @@
+{
+  "tabs": {
+    "home": "Home",
+    "games": "Games",
+    "apps": "Apps",
+    "settings": "Settings"
+  },
+  "sources": {
+    "all": "All",
+    "other": "Other"
+  },
+  "launch": {
+    "launching": "Launching",
+    "failed": "Failed to launch",
+    "dismiss": "Dismiss  ·  B"
+  },
+  "artPicker": {
+    "replaceCoverArt": "Replace cover art",
+    "uploadCustomImage": "Upload a custom image",
+    "noArt": "No art",
+    "browseImage": "Browse Image",
+    "saving": "Saving…",
+    "resetToDefault": "Reset to Default"
+  },
+  "sgdb": {
+    "hoverToPreview": "Hover to preview",
+    "failedToLoad": "Failed to load results",
+    "noResults": "No results found",
+    "downloading": "Downloading…",
+    "filter": {
+      "all": "All",
+      "animated": "Animated",
+      "static": "Static",
+      "label": "Filter"
+    }
+  },
+  "artModal": {
+    "browseSgdb": "Browse SteamGridDB",
+    "uploadFile": "Upload File"
+  },
+  "hideModal": {
+    "manageGames": "Manage games",
+    "manageApps": "Manage apps",
+    "hint": "Checked = visible · Uncheck to hide · A to toggle · ↑↓ navigate · Menu to save · B to cancel",
+    "noApps": "No apps found.",
+    "saveChanges_one": "Save {{count}} change",
+    "saveChanges_other": "Save {{count}} changes",
+    "save": "Save"
+  },
+  "settings": {
+    "accentColor": "Accent Color",
+    "theme": "Theme",
+    "backgroundStars": "Background Stars",
+    "backgroundClouds": "Background Clouds",
+    "uiScale": "UI Scale",
+    "resetScale": "Reset Scale to Auto",
+    "scanSteam": "Scan Steam",
+    "scanXbox": "Scan Xbox",
+    "scanStoreApps": "Scan Store Apps",
+    "scanDesktop": "Scan Desktop Shortcuts",
+    "scanBattlenet": "Scan Battle.net",
+    "refreshLibrary": "Refresh Library",
+    "defaultTab": "Default Tab",
+    "repeatSpeed": "Stick Repeat Speed",
+    "launchAtStartup": "Launch at Startup",
+    "heroArtMode": "Hero Art Mode",
+    "controllerTest": "Controller Test",
+    "noController": "No controller detected — connect a gamepad and press any button.",
+    "clearRecents": "Clear Recently Played",
+    "clearCache": "Clear Art Cache",
+    "language": "Language",
+    "version": "LiftOff v{{version}}",
+    "checkUpdates": "Check for Updates",
+    "coffee": "☕ Buy Me a Coffee",
+    "github": "⭐ GitHub",
+    "discord": "💬 Discord",
+    "dividers": {
+      "display": "DISPLAY",
+      "library": "LIBRARY",
+      "behavior": "BEHAVIOR",
+      "controller": "CONTROLLER",
+      "data": "DATA",
+      "about": "ABOUT",
+      "credits": "CREDITS"
+    },
+    "status": {
+      "scanning": "Scanning...",
+      "done": "✓ Done",
+      "refresh": "↵ Refresh",
+      "apply": "↵ Apply",
+      "confirm": "↵ Confirm",
+      "open": "↵ Open",
+      "checking": "Checking...",
+      "upToDate": "✓ Up to date",
+      "updateAvailable": "↓ v{{version}} available",
+      "checkFailed": "⚠ Check failed",
+      "check": "↵ Check"
+    },
+    "attribution": "by {{author}} · {{license}}",
+    "values": {
+      "dark": "Dark",
+      "light": "Light",
+      "system": "System",
+      "slow": "Slow",
+      "normal": "Normal",
+      "fast": "Fast",
+      "static": "Static",
+      "animated": "Animated",
+      "custom": "Custom",
+      "Home": "Home",
+      "Games": "Games",
+      "Apps": "Apps",
+      "auto": "Auto",
+      "en": "English",
+      "fr": "Français"
+    }
+  },
+  "home": {
+    "resumePlaying": "▶ Resume playing",
+    "recentlyPlayed": "▶ Recently played",
+    "game": "Game",
+    "launch": "Launch",
+    "noGames": "Launch a game to see it here",
+    "noRecents": "Nothing here yet — launch something!",
+    "pinHint": "Pin apps with X to show them here"
+  },
+  "grid": {
+    "pinned": "Pinned",
+    "unpinHint": "X to unpin",
+    "manage": "Manage"
+  },
+  "library": {
+    "refreshing": "Refreshing library…",
+    "scanning": "Scanning for apps and games"
+  },
+  "cache": {
+    "clearing": "Clearing Cache",
+    "removingFiles": "Removing cached artwork files…",
+    "downloadingArtwork": "Downloading Artwork",
+    "startingDownload_one": "Starting download for {{count}} game…",
+    "startingDownload_other": "Starting download for {{count}} games…",
+    "progress": "{{name}}{{done}} / {{total}} games"
+  },
+  "search": {
+    "placeholder": "Search games & apps…",
+    "mode": {
+      "typing": "Typing",
+      "browsing": "Browsing",
+      "idle": "Idle"
+    },
+    "results_one": "{{count}} result",
+    "results_other": "{{count}} results",
+    "startToBrowse": "— ⊞ Start to browse",
+    "idleHint": "— Y to type · ⊞ to browse",
+    "startBrowse": "⊞ Start → Browse"
+  },
+  "contextMenu": {
+    "open": "Open",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "changeArt": "Change Art",
+    "changeHeroArt": "Change Hero Art"
+  },
+  "gamepad": {
+    "aSelect": "A Select",
+    "aLaunch": "A Launch",
+    "aConfirm": "A Confirm",
+    "bBack": "B Back",
+    "bCancel": "B Cancel",
+    "bClose": "B Close",
+    "ySearch": "Y Search",
+    "yKeyboard": "Y Keyboard",
+    "xPin": "X Pin",
+    "tabs": "Tabs",
+    "source": "Source",
+    "options": "Options"
+  },
+  "keyboard": {
+    "numbersAndSymbols": "Numbers & Symbols",
+    "letters": "Letters",
+    "type": "Type",
+    "delete": "Delete",
+    "space": "Space",
+    "results": "Results"
+  },
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "clear": "Clear",
+    "close": "Close",
+    "select": "Select",
+    "retry": "Retry"
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,194 @@
+{
+  "tabs": {
+    "home": "Accueil",
+    "games": "Jeux",
+    "apps": "Apps",
+    "settings": "Paramètres"
+  },
+  "sources": {
+    "all": "Tous",
+    "other": "Autres"
+  },
+  "launch": {
+    "launching": "Lancement",
+    "failed": "Échec du lancement",
+    "dismiss": "Ignorer  ·  B"
+  },
+  "artPicker": {
+    "replaceCoverArt": "Remplacer la couverture",
+    "uploadCustomImage": "Télécharger une image",
+    "noArt": "Pas d'image",
+    "browseImage": "Parcourir",
+    "saving": "Sauvegarde…",
+    "resetToDefault": "Réinitialiser"
+  },
+  "sgdb": {
+    "hoverToPreview": "Survoler pour prévisualiser",
+    "failedToLoad": "Échec du chargement",
+    "noResults": "Aucun résultat",
+    "downloading": "Téléchargement…",
+    "filter": {
+      "all": "Tous",
+      "animated": "Animés",
+      "static": "Statiques",
+      "label": "Filtrer"
+    }
+  },
+  "artModal": {
+    "browseSgdb": "Parcourir SteamGridDB",
+    "uploadFile": "Télécharger un fichier"
+  },
+  "hideModal": {
+    "manageGames": "Gérer les jeux",
+    "manageApps": "Gérer les apps",
+    "hint": "Coché = visible · Décocher pour masquer · A = basculer · ↑↓ naviguer · Menu = sauvegarder · B = annuler",
+    "noApps": "Aucune app trouvée.",
+    "saveChanges_one": "Sauvegarder {{count}} modification",
+    "saveChanges_other": "Sauvegarder {{count}} modifications",
+    "save": "Sauvegarder"
+  },
+  "settings": {
+    "accentColor": "Couleur d'accent",
+    "theme": "Thème",
+    "backgroundStars": "Étoiles de fond",
+    "backgroundClouds": "Nuages de fond",
+    "uiScale": "Échelle UI",
+    "resetScale": "Réinitialiser l'échelle",
+    "scanSteam": "Scanner Steam",
+    "scanXbox": "Scanner Xbox",
+    "scanStoreApps": "Scanner les apps du Store",
+    "scanDesktop": "Scanner les raccourcis Bureau",
+    "scanBattlenet": "Scanner Battle.net",
+    "refreshLibrary": "Actualiser la bibliothèque",
+    "defaultTab": "Onglet par défaut",
+    "repeatSpeed": "Vitesse de répétition",
+    "launchAtStartup": "Lancer au démarrage",
+    "heroArtMode": "Mode art héros",
+    "controllerTest": "Test manette",
+    "noController": "Aucune manette détectée — connectez un contrôleur et appuyez sur un bouton.",
+    "clearRecents": "Effacer l'historique",
+    "clearCache": "Vider le cache art",
+    "language": "Langue",
+    "version": "LiftOff v{{version}}",
+    "checkUpdates": "Vérifier les mises à jour",
+    "coffee": "☕ Offrir un café",
+    "github": "⭐ GitHub",
+    "discord": "💬 Discord",
+    "dividers": {
+      "display": "AFFICHAGE",
+      "library": "BIBLIOTHÈQUE",
+      "behavior": "COMPORTEMENT",
+      "controller": "MANETTE",
+      "data": "DONNÉES",
+      "about": "À PROPOS",
+      "credits": "CRÉDITS"
+    },
+    "status": {
+      "scanning": "Analyse...",
+      "done": "✓ Terminé",
+      "refresh": "↵ Actualiser",
+      "apply": "↵ Appliquer",
+      "confirm": "↵ Confirmer",
+      "open": "↵ Ouvrir",
+      "checking": "Vérification...",
+      "upToDate": "✓ À jour",
+      "updateAvailable": "↓ v{{version}} disponible",
+      "checkFailed": "⚠ Échec de la vérification",
+      "check": "↵ Vérifier"
+    },
+    "attribution": "par {{author}} · {{license}}",
+    "values": {
+      "dark": "Sombre",
+      "light": "Clair",
+      "system": "Système",
+      "slow": "Lent",
+      "normal": "Normal",
+      "fast": "Rapide",
+      "static": "Statique",
+      "animated": "Animé",
+      "custom": "Personnalisé",
+      "Home": "Accueil",
+      "Games": "Jeux",
+      "Apps": "Apps",
+      "auto": "Auto",
+      "en": "English",
+      "fr": "Français"
+    }
+  },
+  "home": {
+    "resumePlaying": "▶ Reprendre",
+    "recentlyPlayed": "▶ Joué récemment",
+    "game": "Jeu",
+    "launch": "Lancer",
+    "noGames": "Lancez un jeu pour le voir ici",
+    "noRecents": "Rien ici pour l'instant — lancez quelque chose !",
+    "pinHint": "Épinglez des apps avec X pour les afficher ici"
+  },
+  "grid": {
+    "pinned": "Épinglés",
+    "unpinHint": "X pour désépingler",
+    "manage": "Gérer"
+  },
+  "library": {
+    "refreshing": "Actualisation…",
+    "scanning": "Recherche d'apps et de jeux"
+  },
+  "cache": {
+    "clearing": "Nettoyage du cache",
+    "removingFiles": "Suppression des fichiers d'art en cache…",
+    "downloadingArtwork": "Téléchargement des illustrations",
+    "startingDownload_one": "Démarrage pour {{count}} jeu…",
+    "startingDownload_other": "Démarrage pour {{count}} jeux…",
+    "progress": "{{name}}{{done}} / {{total}} jeux"
+  },
+  "search": {
+    "placeholder": "Rechercher jeux et apps…",
+    "mode": {
+      "typing": "Saisie",
+      "browsing": "Navigation",
+      "idle": "Inactif"
+    },
+    "results_one": "{{count}} résultat",
+    "results_other": "{{count}} résultats",
+    "startToBrowse": "— ⊞ Start pour naviguer",
+    "idleHint": "— Y pour saisir · ⊞ pour naviguer",
+    "startBrowse": "⊞ Start → Naviguer"
+  },
+  "contextMenu": {
+    "open": "Ouvrir",
+    "pin": "Épingler",
+    "unpin": "Désépingler",
+    "changeArt": "Changer l'illustration",
+    "changeHeroArt": "Changer l'art héros"
+  },
+  "gamepad": {
+    "aSelect": "A Sélectionner",
+    "aLaunch": "A Lancer",
+    "aConfirm": "A Confirmer",
+    "bBack": "B Retour",
+    "bCancel": "B Annuler",
+    "bClose": "B Fermer",
+    "ySearch": "Y Rechercher",
+    "yKeyboard": "Y Clavier",
+    "xPin": "X Épingler",
+    "tabs": "Onglets",
+    "source": "Source",
+    "options": "Options"
+  },
+  "keyboard": {
+    "numbersAndSymbols": "Chiffres et symboles",
+    "letters": "Lettres",
+    "type": "Taper",
+    "delete": "Supprimer",
+    "space": "Espace",
+    "results": "Résultats"
+  },
+  "common": {
+    "save": "Sauvegarder",
+    "cancel": "Annuler",
+    "clear": "Effacer",
+    "close": "Fermer",
+    "select": "Sélectionner",
+    "retry": "Réessayer"
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,6 +69,10 @@
     "clearRecents": "Effacer l'historique",
     "clearCache": "Vider le cache art",
     "language": "Langue",
+    "timeFormat": "Format de l'heure",
+    "showClock": "Afficher l'heure",
+    "showDate": "Afficher la date",
+    "showBattery": "Afficher la batterie",
     "version": "LiftOff v{{version}}",
     "checkUpdates": "Vérifier les mises à jour",
     "coffee": "☕ Offrir un café",
@@ -112,7 +116,9 @@
       "Apps": "Apps",
       "auto": "Auto",
       "en": "English",
-      "fr": "Français"
+      "fr": "Français",
+      "12h": "12h",
+      "24h": "24h"
     }
   },
   "home": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./i18n";
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")).render(


### PR DESCRIPTION
You must wait until https://github.com/PixelateWizard/LiftOff/pull/3 is merged before merging this PR

- Clock and date are now independently toggleable
- Battery widget auto-hides when no battery is detected (desktop)
- Add show_battery toggle in settings
- Time format cycle: auto / 12h / 24h (auto follows locale)
- Date now translates based on active i18n language

<img width="1677" height="769" alt="Capture d’écran 2026-04-27 à 12 36 41" src="https://github.com/user-attachments/assets/69dafd63-20c4-4285-a845-da983bae486b" />
