### PR TITLE
feat: add manual game/app entry and custom scan folder support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,15 @@
         "i18next-browser-languagedetector": "^8.2.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-i18next": "^17.0.4"
+        "react-i18next": "^17.0.4",
+        "react-icons": "^5.6.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.6.0",
+        "typescript": "^6.0.3",
         "vite": "^7.0.4"
       }
     },
@@ -1450,6 +1454,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1543,6 +1567,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1885,6 +1916,15 @@
         }
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1981,6 +2021,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-i18next": "^17.0.4"
+    "react-i18next": "^17.0.4",
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.6.0",
+    "typescript": "^6.0.3",
     "vite": "^7.0.4"
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,6 +303,55 @@ fn save_hidden_inner(hidden: &Vec<String>) {
     if let Ok(json) = serde_json::to_string(hidden) { let _ = std::fs::write(path, json); }
 }
 
+// ── Custom entries (manually added apps + scan folders) ────────────────────────
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CustomFolder {
+    pub id: String,
+    pub path: String,
+    pub source: String,
+    pub app_type: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+fn default_true() -> bool { true }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct AppCollection {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct CustomData {
+    #[serde(default)]
+    pub apps: Vec<AppEntry>,
+    #[serde(default)]
+    pub folders: Vec<CustomFolder>,
+    #[serde(default)]
+    pub app_collections: Vec<AppCollection>,
+    #[serde(default)]
+    pub app_memberships: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub game_collections: Vec<AppCollection>,
+    #[serde(default)]
+    pub game_memberships: HashMap<String, Vec<String>>,
+}
+
+fn custom_data_path() -> std::path::PathBuf { liftoff_dir().join("custom_data.json") }
+
+fn load_custom_data() -> CustomData {
+    let path = custom_data_path();
+    if !path.exists() { return CustomData::default(); }
+    std::fs::read_to_string(&path).ok().and_then(|s| serde_json::from_str(&s).ok()).unwrap_or_default()
+}
+
+fn save_custom_data(data: &CustomData) {
+    let path = custom_data_path();
+    if let Some(parent) = path.parent() { let _ = std::fs::create_dir_all(parent); }
+    if let Ok(json) = serde_json::to_string(data) { let _ = std::fs::write(path, json); }
+}
+
 fn custom_art_path() -> std::path::PathBuf { liftoff_dir().join("custom_art.json") }
 
 fn load_custom_art_inner() -> HashMap<String, String> {
@@ -315,6 +364,196 @@ fn save_custom_art_inner(map: &HashMap<String, String>) {
     let path = custom_art_path();
     if let Some(parent) = path.parent() { let _ = std::fs::create_dir_all(parent); }
     if let Ok(json) = serde_json::to_string(map) { let _ = std::fs::write(path, json); }
+}
+
+// ── File browser ───────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct FileEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub extension: String,
+}
+
+#[tauri::command]
+fn list_dir(path: String) -> Vec<FileEntry> {
+    let p = std::path::Path::new(&path);
+    if !p.exists() || !p.is_dir() { return vec![]; }
+    let mut dirs: Vec<FileEntry> = Vec::new();
+    let mut files: Vec<FileEntry> = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(p) {
+        for entry in rd.flatten() {
+            let ep = entry.path();
+            let name = ep.file_name().and_then(|n| n.to_str()).unwrap_or("").to_string();
+            if name.starts_with('$') { continue; }
+            let path_str = ep.to_string_lossy().to_string();
+            let ext = ep.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
+            if ep.is_dir() {
+                dirs.push(FileEntry { name, path: path_str, is_dir: true, extension: String::new() });
+            } else if ext == "exe" || ext == "lnk" {
+                files.push(FileEntry { name, path: path_str, is_dir: false, extension: ext });
+            }
+        }
+    }
+    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    dirs.extend(files);
+    dirs
+}
+
+#[tauri::command]
+fn get_drives() -> Vec<FileEntry> {
+    let mut drives = Vec::new();
+    for c in b'A'..=b'Z' {
+        let drive = format!("{}:\\", c as char);
+        if std::path::Path::new(&drive).exists() {
+            drives.push(FileEntry { name: drive.clone(), path: drive, is_dir: true, extension: String::new() });
+        }
+    }
+    drives
+}
+
+#[tauri::command]
+fn get_custom_data() -> CustomData { load_custom_data() }
+
+#[tauri::command]
+fn add_custom_app(name: String, path: String, app_type: String, source: String) -> Result<AppEntry, String> {
+    let mut data = load_custom_data();
+    let id = format!("custom_{}", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis());
+    let icon = extract_icon_base64(&path);
+    let entry = AppEntry { id, name, icon_base64: icon, launch_path: path, app_type, source };
+    data.apps.push(entry.clone());
+    save_custom_data(&data);
+    Ok(entry)
+}
+
+#[tauri::command]
+fn remove_custom_app(id: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    data.apps.retain(|a| a.id != id);
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn add_custom_folder(path: String, source: String, app_type: String) -> Result<CustomFolder, String> {
+    let mut data = load_custom_data();
+    let id = format!("folder_{}", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis());
+    let folder = CustomFolder { id, path, source, app_type, enabled: true };
+    data.folders.push(folder.clone());
+    save_custom_data(&data);
+    Ok(folder)
+}
+
+#[tauri::command]
+fn remove_custom_folder(id: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    data.folders.retain(|f| f.id != id);
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn toggle_custom_folder(id: String, enabled: bool) -> Result<(), String> {
+    let mut data = load_custom_data();
+    if let Some(f) = data.folders.iter_mut().find(|f| f.id == id) { f.enabled = enabled; }
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn get_app_collections() -> Vec<AppCollection> { load_custom_data().app_collections }
+
+#[tauri::command]
+fn create_app_collection(name: String) -> Result<AppCollection, String> {
+    let mut data = load_custom_data();
+    let id = format!("col_{}", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis());
+    let col = AppCollection { id, name };
+    data.app_collections.push(col.clone());
+    save_custom_data(&data);
+    Ok(col)
+}
+
+#[tauri::command]
+fn delete_app_collection(id: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    data.app_collections.retain(|c| c.id != id);
+    data.app_memberships.retain(|_, v| { v.retain(|cid| cid != &id); true });
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn rename_app_collection(id: String, name: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    if let Some(c) = data.app_collections.iter_mut().find(|c| c.id == id) { c.name = name; }
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn get_app_memberships() -> HashMap<String, Vec<String>> { load_custom_data().app_memberships }
+
+#[tauri::command]
+fn set_app_memberships(app_id: String, collection_ids: Vec<String>) -> Result<(), String> {
+    let mut data = load_custom_data();
+    if collection_ids.is_empty() {
+        data.app_memberships.remove(&app_id);
+    } else {
+        data.app_memberships.insert(app_id, collection_ids);
+    }
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn get_game_collections() -> Vec<AppCollection> { load_custom_data().game_collections }
+
+#[tauri::command]
+fn create_game_collection(name: String) -> Result<AppCollection, String> {
+    let mut data = load_custom_data();
+    let id = format!("gcol_{}", std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_millis());
+    let col = AppCollection { id, name };
+    data.game_collections.push(col.clone());
+    save_custom_data(&data);
+    Ok(col)
+}
+
+#[tauri::command]
+fn delete_game_collection(id: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    data.game_collections.retain(|c| c.id != id);
+    data.game_memberships.retain(|_, v| { v.retain(|cid| cid != &id); true });
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn rename_game_collection(id: String, name: String) -> Result<(), String> {
+    let mut data = load_custom_data();
+    if let Some(c) = data.game_collections.iter_mut().find(|c| c.id == id) { c.name = name; }
+    save_custom_data(&data);
+    Ok(())
+}
+
+#[tauri::command]
+fn get_game_memberships() -> HashMap<String, Vec<String>> { load_custom_data().game_memberships }
+
+#[tauri::command]
+fn set_game_memberships(app_id: String, collection_ids: Vec<String>) -> Result<(), String> {
+    let mut data = load_custom_data();
+    if collection_ids.is_empty() {
+        data.game_memberships.remove(&app_id);
+    } else {
+        data.game_memberships.insert(app_id, collection_ids);
+    }
+    save_custom_data(&data);
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -802,15 +1041,26 @@ fn extract_uwp_icon_base64(install_location: &str, logo_hint: &str) -> Option<St
 }
 
 fn scan_folder(folder: &str, app_type: &str) -> Vec<AppEntry> {
+    scan_folder_with_source(folder, app_type, "desktop")
+}
+
+fn scan_folder_with_source(folder: &str, app_type: &str, source: &str) -> Vec<AppEntry> {
     let mut entries = Vec::new();
-    let path = Path::new(folder);
-    if !path.exists() { return entries; }
-    if let Ok(dir) = std::fs::read_dir(path) {
-        for entry in dir.flatten() {
-            let p = entry.path();
-            let path_str = p.to_string_lossy().to_string();
-            // Exclude LiftOff's own build artifacts
-            if path_str.contains("target\\release") || path_str.contains("target/release") { continue; }
+    scan_folder_recursive(Path::new(folder), app_type, source, 0, &mut entries);
+    entries
+}
+
+fn scan_folder_recursive(path: &Path, app_type: &str, source: &str, depth: u32, entries: &mut Vec<AppEntry>) {
+    if depth > 4 { return; }
+    if !path.exists() { return; }
+    let Ok(dir) = std::fs::read_dir(path) else { return; };
+    for entry in dir.flatten() {
+        let p = entry.path();
+        let path_str = p.to_string_lossy().to_string();
+        if path_str.contains("target\\release") || path_str.contains("target/release") { continue; }
+        if p.is_dir() {
+            scan_folder_recursive(&p, app_type, source, depth + 1, entries);
+        } else {
             let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
             if ext == "lnk" || ext == "exe" {
                 let name = p.file_stem().and_then(|n| n.to_str()).unwrap_or("Unknown").to_string();
@@ -821,12 +1071,11 @@ fn scan_folder(folder: &str, app_type: &str) -> Vec<AppEntry> {
                     icon_base64: icon,
                     launch_path: path_str,
                     app_type: app_type.to_string(),
-                    source: "desktop".to_string(),
+                    source: source.to_string(),
                 });
             }
         }
     }
-    entries
 }
 
 fn is_valid_display_name(name: &str) -> bool {
@@ -1286,6 +1535,27 @@ fn get_all_apps() -> Vec<AppEntry> {
     // Deduplicate only — no hidden filter
     let mut seen = std::collections::HashSet::new();
     apps.retain(|a| seen.insert(a.id.clone()));
+
+    // Merge custom entries (manually added apps + scanned custom folders)
+    let custom = load_custom_data();
+    // Build a set of known launch paths (lowercase) from manually-added apps
+    // so that folder scans don't produce duplicates for the same executable.
+    let mut known_paths: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for app in &custom.apps {
+        known_paths.insert(app.launch_path.to_lowercase());
+        if seen.insert(app.id.clone()) { apps.push(app.clone()); }
+    }
+    for folder in custom.folders {
+        if !folder.enabled { continue; }
+        for app in scan_folder_with_source(&folder.path, &folder.app_type, &folder.source) {
+            if known_paths.contains(&app.launch_path.to_lowercase()) { continue; }
+            if seen.insert(app.id.clone()) {
+                known_paths.insert(app.launch_path.to_lowercase());
+                apps.push(app);
+            }
+        }
+    }
+
     apps
 }
 
@@ -1559,7 +1829,14 @@ pub fn run() {
             get_hidden, toggle_hidden,
             get_custom_art, set_custom_art, clear_custom_art,
             get_screen_resolution,
-            search_sgdb_art, download_sgdb_art
+            search_sgdb_art, download_sgdb_art,
+            list_dir, get_drives,
+            get_custom_data, add_custom_app, remove_custom_app,
+            add_custom_folder, remove_custom_folder, toggle_custom_folder,
+            get_app_collections, create_app_collection, delete_app_collection, rename_app_collection,
+            get_app_memberships, set_app_memberships,
+            get_game_collections, create_game_collection, delete_game_collection, rename_game_collection,
+            get_game_memberships, set_game_memberships
         ])
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,17 @@ import { useTranslation } from "react-i18next";
 import i18n from "./i18n";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import FileBrowser from "./components/FileBrowser";
+import GamepadKeyboard from "./components/GamepadKeyboard";
+import { GamepadBtn } from "./components/GamepadBtn";
+import AddEntryModal from "./components/modals/AddEntryModal";
+import ConfirmModal from "./components/modals/ConfirmModal";
+import FolderManagerModal from "./components/modals/FolderManagerModal";
+import ColPickerModal from "./components/modals/ColPickerModal";
+import CollectionManagerModal from "./components/modals/CollectionManagerModal";
+import ModalShell from "./components/modals/ModalShell";
+import ContextMenuModal from "./components/modals/ContextMenuModal";
+import HideModal from "./components/modals/HideModal";
 import uiSound from "./assets/uiSound.mp3";
 import uiSoundAlt from "./assets/uiSoundAlt.mp3";
 import startingSound from "./assets/appLaunchSound.wav";
@@ -1233,237 +1244,6 @@ function ControllerTestWidget({ accent, theme, isDark, glass }) {
   );
 }
 
-// ── Manage Apps Modal ─────────────────────────────────────────
-// Defined outside App so the component type is stable across re-renders.
-// If it were defined inside App, every clock-tick re-render would create a
-
-// new function reference, causing React to unmount/remount and wipe state.
-//
-// Shows all apps (visible + hidden) in one list.
-// Checked = shown in launcher. Uncheck to hide, check to restore.
-function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggleHidden, glass, accent, isDark, theme }) {
-    const { t } = useTranslation();
-    const visibleApps = appsRef.current.filter(a => tab === "Games" ? a.app_type === "game" : a.app_type === "app");
-    const hiddenIds   = hiddenRef.current;
-
-    // Checked = currently visible. Unchecked = hidden.
-    const [localChecked, setLocalChecked] = useState(() => new Set(visibleApps.map(a => a.id)));
-    const [focusIdx, setFocusIdx] = useState(0);
-    const focusIdxRef = useRef(0);
-    const listRef     = useRef(null);
-
-    // Combined list: visible apps first, then hidden apps (with full data looked up from allAppsRef)
-    const hiddenApps = hiddenIds.map(id => {
-      const full = allAppsRef.current.find(a => a.id === id);
-      return full ? { ...full, _hidden: true } : { id, name: id, _hidden: true };
-    }).filter(a => tab === "Games" ? a.app_type === "game" : a.app_type === "app" || !a.app_type);
-    const allItems = [...visibleApps.map(a => ({ ...a, _hidden: false })), ...hiddenApps];
-
-    // Keep refs current so the no-dep effect can always read latest values
-    const allItemsRef     = useRef(allItems);
-    const localCheckedRef = useRef(localChecked);
-    useEffect(() => { allItemsRef.current     = allItems;     });
-    useEffect(() => { localCheckedRef.current = localChecked; });
-
-    // Scroll focused row into view
-    useEffect(() => {
-      if (listRef.current) {
-        const rows = listRef.current.querySelectorAll("[data-modal-row]");
-        if (rows[focusIdx]) rows[focusIdx].scrollIntoView({ block: "nearest", behavior: "smooth" });
-      }
-    }, [focusIdx]);
-
-    // No-dep effect — all mutable state accessed via refs
-    useEffect(() => {
-      let closed = false;
-
-      const toggleItem = (i) => {
-        const item = allItemsRef.current[i];
-        if (!item) return;
-        setLocalChecked(prev => { const n = new Set(prev); n.has(item.id) ? n.delete(item.id) : n.add(item.id); return n; });
-      };
-
-      const doClose = () => { closed = true; closeHideModal(); };
-
-      const doConfirm = () => {
-        closed = true;
-        const checked = localCheckedRef.current;
-        const items   = allItemsRef.current;
-        // Hide visible apps that were unchecked
-        items.filter(a => !a._hidden && !checked.has(a.id)).forEach(a => toggleHidden(a.id));
-        // Restore hidden apps that were checked
-        items.filter(a =>  a._hidden &&  checked.has(a.id)).forEach(a => toggleHidden(a.id));
-        closeHideModal();
-      };
-
-      const handle = (key) => {
-        if (closed) return;
-        const total      = allItemsRef.current.length + 2;
-        const cancelIdx  = allItemsRef.current.length;
-        const confirmIdx = allItemsRef.current.length + 1;
-        if      (key === "ArrowDown" || key === "ArrowRight") { const ni = Math.min(focusIdxRef.current + 1, total - 1); setFocusIdx(ni); focusIdxRef.current = ni; }
-        else if (key === "ArrowUp"   || key === "ArrowLeft")  { const ni = Math.max(focusIdxRef.current - 1, 0);         setFocusIdx(ni); focusIdxRef.current = ni; }
-        else if (key === "Enter") {
-          const i = focusIdxRef.current;
-          if      (i === cancelIdx)  doClose();
-          else if (i === confirmIdx) doConfirm();
-          else                       toggleItem(i);
-        }
-        else if (key === "Start")  doConfirm();
-        else if (key === "Escape") doClose();
-      };
-
-      // Keyboard — capture phase, runs before main handler guard
-      const onKey = (e) => {
-        if (closed) return;
-        const map = { ArrowDown:"ArrowDown", ArrowUp:"ArrowUp", ArrowLeft:"ArrowLeft", ArrowRight:"ArrowRight", Enter:"Enter", Escape:"Escape", " ":"Enter" };
-        if (map[e.key]) { e.preventDefault(); e.stopPropagation(); handle(map[e.key]); }
-      };
-      window.addEventListener("keydown", onKey, true);
-
-      // Gamepad poll with hold-repeat for directions
-      let rAF;
-      const lastBtn   = {};
-      const pressTime = {};
-      const repeating = {};
-      const DIRS      = new Set(["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"]);
-      const INIT_MS   = 400;
-      const RPT_MS    = 100;
-      let startReleased = false;
-
-      const pollModal = (now) => {
-        if (closed) return;
-        const gp  = getBestGamepad();
-        if (gp) {
-          const base = readGpState(gp);
-          if (!base.Start) startReleased = true;
-          const state = { ...base, Start: startReleased && base.Start };
-          Object.keys(state).forEach(k => {
-            const pressed = state[k], was = lastBtn[k];
-            if (pressed && !was) {
-              handle(k); pressTime[k] = now; repeating[k] = false;
-            } else if (pressed && was && DIRS.has(k)) {
-              const held = now - (pressTime[k] || now);
-              if (!repeating[k] && held >= INIT_MS) { repeating[k] = true; pressTime[k] = now; handle(k); }
-              else if (repeating[k] && held >= RPT_MS) { pressTime[k] = now; handle(k); }
-            } else if (!pressed && was) { pressTime[k] = 0; repeating[k] = false; }
-            lastBtn[k] = pressed;
-          });
-        }
-        rAF = requestAnimationFrame(pollModal);
-      };
-      rAF = requestAnimationFrame(pollModal);
-
-      return () => { closed = true; window.removeEventListener("keydown", onKey, true); cancelAnimationFrame(rAF); };
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-    const listLen    = allItems.length;
-    const cancelIdx  = listLen;
-    const confirmIdx = listLen + 1;
-
-    const pendingHide    = visibleApps.filter(a => !localChecked.has(a.id)).length;
-    const pendingRestore = hiddenIds.filter(id => localChecked.has(id)).length;
-    const changeCount    = pendingHide + pendingRestore;
-
-    return (
-      <div
-        data-modal-overlay
-        onMouseDown={e => e.stopPropagation()}
-        onClick={e => e.stopPropagation()}
-        onDoubleClick={e => e.stopPropagation()}
-        style={{
-          position: "fixed", inset: 0, zIndex: 8500,
-          background: "rgba(0,0,0,0.75)", backdropFilter: "blur(16px)", WebkitBackdropFilter: "blur(16px)",
-          display: "flex", alignItems: "center", justifyContent: "center",
-          fontFamily: "'Segoe UI', sans-serif",
-          userSelect: "none",
-        }}>
-        <div data-modal-container style={{ ...glass, borderRadius: 20, width: "min(600px, 90vw)", maxHeight: "75vh",
-          display: "flex", flexDirection: "column", overflow: "hidden",
-          border: `1px solid ${accent.glow}0.3)` }}>
-
-          {/* Header */}
-          <div style={{ padding: "20px 24px 14px", borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}`, flexShrink: 0 }}>
-            <div style={{ fontSize: 16, fontWeight: 700, color: theme.text, marginBottom: 4 }}>
-              {tab === "Games" ? t('hideModal.manageGames') : t('hideModal.manageApps')}
-            </div>
-            <div style={{ fontSize: 12, color: theme.textDim }}>
-              {t('hideModal.hint')}
-            </div>
-          </div>
-
-          {/* List */}
-          <div ref={listRef} style={{ overflowY: "auto", flex: 1, padding: "8px 0" }}>
-            {allItems.length === 0 && (
-              <div style={{ padding: "40px 24px", textAlign: "center", color: theme.textFaint, fontSize: 13 }}>{t('hideModal.noApps')}</div>
-            )}
-            {allItems.map((item, i) => {
-              const checked  = localChecked.has(item.id);
-              const rowFocus = focusIdx === i;
-              const isHidden = item._hidden;
-              return (
-                <div key={item.id} data-modal-row
-                  onClick={() => { setFocusIdx(i); focusIdxRef.current = i; setLocalChecked(prev => { const n = new Set(prev); checked ? n.delete(item.id) : n.add(item.id); return n; }); }}
-                  style={{ display: "flex", alignItems: "center", gap: 14, padding: "10px 24px", cursor: "pointer",
-                    background: rowFocus ? `${accent.glow}0.12)` : "transparent",
-                    borderLeft: `3px solid ${rowFocus ? accent.primary : "transparent"}`,
-                    opacity: isHidden && !checked ? 0.5 : 1,
-                    transition: "all 0.1s ease" }}>
-                  <div style={{ width: 20, height: 20, borderRadius: 5, flexShrink: 0,
-                    border: `2px solid ${checked ? accent.primary : (isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)")}`,
-                    background: checked ? accent.primary : "transparent",
-                    display: "flex", alignItems: "center", justifyContent: "center", transition: "all 0.1s ease" }}>
-                    {checked && <svg width="11" height="11" viewBox="0 0 12 12" fill="none"><path d="M2 6l3 3 5-5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>}
-                  </div>
-                  {item.icon_base64
-                    ? <div style={{ width: 28, height: 28, borderRadius: 6, overflow: "hidden", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-                        <img src={`data:image/png;base64,${item.icon_base64}`} alt={item.name} style={{ width: "100%", height: "100%", maxWidth: "100%", maxHeight: "100%", objectFit: "contain", objectPosition: "center", display: "block" }} />
-                      </div>
-                    : <div style={{ width: 28, height: 28, borderRadius: 6, background: `${accent.glow}0.15)`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: accent.primary, flexShrink: 0 }}>{(item.name || "?")[0]}</div>
-                  }
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontSize: 13, fontWeight: 500, color: theme.text, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                      {item.name || item.id}
-                    </div>
-                    <div style={{ fontSize: 10, color: theme.textFaint, textTransform: "capitalize" }}>
-                      {isHidden ? `${item.source || "hidden"}` : item.source}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Footer */}
-          <div style={{ padding: "14px 24px", borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}`,
-            display: "flex", gap: 10, justifyContent: "flex-end", flexShrink: 0 }}>
-            <div data-modal-row onClick={closeHideModal}
-              style={{ padding: "9px 20px", borderRadius: 10, cursor: "pointer", fontSize: 13, fontWeight: 600,
-                color: theme.textDim,
-                background: focusIdx === cancelIdx ? (isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)") : (isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)"),
-                border: `2px solid ${focusIdx === cancelIdx ? accent.primary : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
-                transition: "all 0.1s ease" }}>
-              {t('common.cancel')}
-            </div>
-            <div data-modal-row onClick={() => {
-                const checked = localChecked;
-                visibleApps.filter(a => !checked.has(a.id)).forEach(a => toggleHidden(a.id));
-                hiddenIds.filter(id => checked.has(id)).forEach(id => toggleHidden(id));
-                closeHideModal();
-              }}
-              style={{ padding: "9px 20px", borderRadius: 10, cursor: "pointer", fontSize: 13, fontWeight: 600,
-                color: "white",
-                background: focusIdx === confirmIdx ? accent.light : accent.primary,
-                border: `2px solid ${focusIdx === confirmIdx ? "white" : accent.primary}`,
-                boxShadow: `0 2px 12px ${accent.glow}0.4)`,
-                transition: "all 0.1s ease" }}>
-              {changeCount > 0 ? t('hideModal.saveChanges', { count: changeCount }) : t('hideModal.save')}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-}
 // ─────────────────────────────────────────────────────────────
 
 async function sampleIconColor(base64) {
@@ -1502,6 +1282,20 @@ export default function App() {
   const [gameSourceTab, setGameSourceTab]           = useState("All"); // "All" | "Steam" | "Xbox" | "Other"
   const [subtabFocusIndex, setSubtabFocusIndex]     = useState(0);    // index within subtab row
   const [showHideModal, setShowHideModal]           = useState(false);
+  const [showFileBrowser, setShowFileBrowser]       = useState(null);  // null | "file" | "folder"
+  const [addAppType, setAddAppType]                 = useState("game"); // "game" | "app"
+  const [pendingFile, setPendingFile]               = useState(null);  // FileEntry from FileBrowser
+  const [customSources, setCustomSources]           = useState([]);    // extra source names
+  const [customFolders, setCustomFolders]           = useState([]);    // { id, path, source, app_type, enabled }
+  const [appCollections, setAppCollections]         = useState([]);    // { id, name }
+  const [appMemberships, setAppMemberships]         = useState({});    // app_id -> [collection_id, ...]
+  const [appCollectionTab, setAppCollectionTab]     = useState("All"); // selected collection in Apps tab
+  const [gameCollections, setGameCollections]       = useState([]);    // { id, name }
+  const [gameMemberships, setGameMemberships]       = useState({});    // game_id -> [collection_id, ...]
+  const [showColModal, setShowColModal]             = useState(false); // collection manager modal
+  const [colPickerApp, setColPickerApp]             = useState(null);  // app whose collections are being edited
+  const [confirmDelete, setConfirmDelete]           = useState(null);  // app pending deletion confirm
+  const [showFolderManager, setShowFolderManager]   = useState(false); // folder manager modal
   const [loading, setLoading]                       = useState(true);
   const [splashExiting, setSplashExiting]           = useState(false);
   const [focusSection, setFocusSection]             = useState("hero");
@@ -1580,6 +1374,18 @@ export default function App() {
   const gameSourceTabRef      = useRef("All");
   const subtabFocusIndexRef   = useRef(0);
   const showHideModalRef      = useRef(false);
+  const showFileBrowserRef    = useRef(null);
+  const pendingFileRef        = useRef(null);
+  const customSourcesRef      = useRef([]);
+  const appCollectionsRef     = useRef([]);
+  const appMembershipsRef     = useRef({});
+  const appCollectionTabRef   = useRef("All");
+  const gameCollectionsRef    = useRef([]);
+  const gameMembershipsRef    = useRef({});
+  const showColModalRef       = useRef(false);
+  const colPickerAppRef       = useRef(null);
+  const confirmDeleteRef      = useRef(null);
+  const showFolderManagerRef  = useRef(false);
   const suppressUntilRelease  = useRef({}); // buttons held when modal closed — suppress until released
   const isReadyRef            = useRef(false);
   const heroVideoRefs         = useRef({});
@@ -1777,7 +1583,7 @@ export default function App() {
           }
 
           if (pressed && !wasPressed) {
-            if (!showHideModalRef.current) handleNavRef.current?.(key);
+            if (!showHideModalRef.current && !showFileBrowserRef.current && !pendingFileRef.current) handleNavRef.current?.(key);
             btnPressTime.current[key]  = now;
             btnRepeating.current[key]  = false;
           } else if (pressed && wasPressed && REPEATABLE.has(key)) {
@@ -1785,10 +1591,10 @@ export default function App() {
             if (!btnRepeating.current[key] && heldMs >= initialDelay) {
               btnRepeating.current[key] = true;
               btnPressTime.current[key] = now;
-              if (!showHideModalRef.current) handleNavRef.current?.(key);
+              if (!showHideModalRef.current && !showFileBrowserRef.current && !pendingFileRef.current) handleNavRef.current?.(key);
             } else if (btnRepeating.current[key] && heldMs >= repeatDelay) {
               btnPressTime.current[key] = now;
-              if (!showHideModalRef.current) handleNavRef.current?.(key);
+              if (!showHideModalRef.current && !showFileBrowserRef.current && !pendingFileRef.current) handleNavRef.current?.(key);
             }
           } else if (!pressed && wasPressed) {
             btnPressTime.current[key]  = 0;
@@ -1835,6 +1641,19 @@ export default function App() {
     document.head.appendChild(style);
     return () => style.remove();
   }, []);
+
+  useEffect(() => { showFileBrowserRef.current = showFileBrowser; }, [showFileBrowser]);
+  useEffect(() => { pendingFileRef.current = pendingFile; }, [pendingFile]);
+  useEffect(() => { customSourcesRef.current = customSources; }, [customSources]);
+  useEffect(() => { appCollectionsRef.current = appCollections; }, [appCollections]);
+  useEffect(() => { appMembershipsRef.current = appMemberships; }, [appMemberships]);
+  useEffect(() => { appCollectionTabRef.current = appCollectionTab; }, [appCollectionTab]);
+  useEffect(() => { gameCollectionsRef.current = gameCollections; }, [gameCollections]);
+  useEffect(() => { gameMembershipsRef.current = gameMemberships; }, [gameMemberships]);
+  useEffect(() => { showColModalRef.current = showColModal; }, [showColModal]);
+  useEffect(() => { colPickerAppRef.current = colPickerApp; }, [colPickerApp]);
+  useEffect(() => { confirmDeleteRef.current = confirmDelete; }, [confirmDelete]);
+  useEffect(() => { showFolderManagerRef.current = showFolderManager; }, [showFolderManager]);
 
   useEffect(() => {
     const currentIsDark = (() => {
@@ -1942,13 +1761,14 @@ export default function App() {
       const auto = Math.min(2.0, Math.max(0.75, Math.min(res.width / 1920, res.height / 1080)));
       autoScaleRef.current = auto;
       // ui_scale is null when never saved; substitute the auto-detected value.
-      const updated = { ...s, ui_scale: s.ui_scale ?? auto };
+      const updated = { ...settingsRef.current, ...s, ui_scale: s.ui_scale ?? auto };
       setSettings(updated); settingsRef.current = updated;
       setTab(s.default_tab || "Home"); tabRef.current = s.default_tab || "Home";
       if (s.language && s.language !== "auto") i18n.changeLanguage(s.language);
     }).catch(() => {
       invoke("get_settings").then(s => {
-        setSettings(s); settingsRef.current = s;
+        const merged = { ...settingsRef.current, ...s };
+        setSettings(merged); settingsRef.current = merged;
         setTab(s.default_tab || "Home"); tabRef.current = s.default_tab || "Home";
         if (s.language && s.language !== "auto") i18n.changeLanguage(s.language);
       });
@@ -1971,6 +1791,26 @@ export default function App() {
     invoke("get_pins").then(loadedPins => {
       setPins(loadedPins); pinsRef.current = loadedPins;
     });
+    invoke("get_custom_data").then(data => {
+      const sources = [...new Set([
+        ...data.apps.map(a => a.source),
+        ...data.folders.map(f => f.source),
+      ])].filter(s => !["Steam","Xbox","Bnet","Other","steam","xbox","battlenet","desktop","uwp"].includes(s));
+      setCustomSources(sources); customSourcesRef.current = sources;
+      setCustomFolders(data.folders || []);
+    }).catch(() => {});
+    invoke("get_app_collections").then(cols => {
+      setAppCollections(cols); appCollectionsRef.current = cols;
+    }).catch(() => {});
+    invoke("get_app_memberships").then(m => {
+      setAppMemberships(m); appMembershipsRef.current = m;
+    }).catch(() => {});
+    invoke("get_game_collections").then(cols => {
+      setGameCollections(cols); gameCollectionsRef.current = cols;
+    }).catch(() => {});
+    invoke("get_game_memberships").then(m => {
+      setGameMemberships(m); gameMembershipsRef.current = m;
+    }).catch(() => {});
     Promise.all([invoke("get_all_apps"), invoke("get_hidden")]).then(([all, loadedHidden]) => {
       allAppsRef.current = all;
       setHidden(loadedHidden); hiddenRef.current = loadedHidden;
@@ -2132,10 +1972,19 @@ export default function App() {
       if (gameSourceTab === "Steam") return a.source === "steam";
       if (gameSourceTab === "Xbox")  return a.source === "xbox";
       if (gameSourceTab === "Bnet")  return a.source === "battlenet";
-      if (gameSourceTab === "Other") return a.source !== "steam" && a.source !== "xbox" && a.source !== "battlenet";
+      if (gameSourceTab === "Other") return a.source !== "steam" && a.source !== "xbox" && a.source !== "battlenet" && !customSources.includes(a.source);
+      if (customSources.includes(gameSourceTab)) return a.source === gameSourceTab;
+      const gameCol = gameCollections.find(c => c.name === gameSourceTab);
+      if (gameCol) return (gameMemberships[a.id] || []).includes(gameCol.id);
       return true; // "All"
     }
-    if (tab === "Apps") return a.app_type === "app";
+    if (tab === "Apps") {
+      if (a.app_type !== "app") return false;
+      if (appCollectionTab === "All") return true;
+      const col = appCollections.find(c => c.name === appCollectionTab);
+      if (!col) return true;
+      return (appMemberships[a.id] || []).includes(col.id);
+    }
     return true;
   });
   const filteredRecent = recent.filter(a =>
@@ -2294,6 +2143,7 @@ export default function App() {
     { key: "scan_uwp",          label: t('settings.scanStoreApps'),                         type: "toggle" },
     { key: "scan_desktop",      label: t('settings.scanDesktop'),                           type: "toggle" },
     { key: "scan_battlenet",    label: t('settings.scanBattlenet'),                         type: "toggle" },
+    { key: "custom_folders",    label: t('settings.customFolders'),                         type: "custom_folders" },
     { key: "refresh_library",   label: t('settings.refreshLibrary'),                        type: "refresh" },
     { key: "divider2",          label: t('settings.dividers.behavior'),                     type: "divider" },
     { key: "default_tab",       label: t('settings.defaultTab'),                            type: "cycle",  options: ["Home","Games","Apps"] },
@@ -2328,7 +2178,7 @@ export default function App() {
   // ── handleNav ─────────────────────────────────────────────────
   const handleNav = (key) => {
     // Modal intercepts all input via its own poll — main nav must not run
-    if (showHideModalRef.current) return;
+    if (showHideModalRef.current || showFileBrowserRef.current || pendingFileRef.current || showFolderManagerRef.current || confirmDeleteRef.current || showColModalRef.current || colPickerAppRef.current) return;
 
     // Art picker open — only Escape closes it (user interacts via touch/mouse)
     if (artPickerAppRef.current) {
@@ -2336,46 +2186,8 @@ export default function App() {
       return;
     }
 
-    // Context menu open — navigate with D-pad, confirm with A, dismiss with B or bumpers
+    // Context menu open — ContextMenuModal owns navigation; main loop just blocks other inputs
     if (contextMenuRef.current) {
-      const menu = contextMenuRef.current;
-      const menuItems = [
-        { key: "open" },
-        { key: pins.includes(menu.app.id) ? "unpin" : "pin" },
-        { key: "changeArt" },
-        ...(menu.app.app_type === "game" ? [{ key: "changeHeroArt" }] : []),
-      ];
-      const cur = menu.focusedIdx || 0;
-      if (key === "ArrowDown") {
-        const next = Math.min(cur + 1, menuItems.length - 1);
-        const updated = { ...menu, focusedIdx: next };
-        setContextMenu(updated); contextMenuRef.current = updated;
-        return;
-      }
-      if (key === "ArrowUp") {
-        const next = Math.max(cur - 1, 0);
-        const updated = { ...menu, focusedIdx: next };
-        setContextMenu(updated); contextMenuRef.current = updated;
-        return;
-      }
-      if (key === "Enter") {
-        const itemKey = menuItems[cur]?.key;
-        if (itemKey === "open") { triggerLaunch(menu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; }
-        else if (itemKey === "pin" || itemKey === "unpin") { togglePin(menu.app); setContextMenu(null); contextMenuRef.current = null; }
-        else if (itemKey === "changeArt") { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
-        else if (itemKey === "changeHeroArt") { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(menu.app); artPickerAppRef.current = menu.app; setContextMenu(null); contextMenuRef.current = null; }
-        return;
-      }
-      if (key === "Escape" || key === "BumperLeft" || key === "BumperRight") {
-        setContextMenu(null); contextMenuRef.current = null;
-        if (key !== "Escape") {
-          // Let bumpers fall through to tab-switching after closing
-          const i = TABS.indexOf(tabRef.current);
-          if (key === "BumperLeft")  switchTab(TABS[(i - 1 + TABS.length) % TABS.length]);
-          if (key === "BumperRight") switchTab(TABS[(i + 1) % TABS.length]);
-        }
-        return;
-      }
       return;
     }
 
@@ -2396,10 +2208,18 @@ export default function App() {
         if (src === "Steam") return a.source === "steam";
         if (src === "Xbox")  return a.source === "xbox";
         if (src === "Bnet")  return a.source === "battlenet";
-        if (src === "Other") return a.source !== "steam" && a.source !== "xbox" && a.source !== "battlenet";
-        return true;
+        if (src === "Other") return a.source !== "steam" && a.source !== "xbox" && a.source !== "battlenet" && !customSourcesRef.current.includes(a.source);
+        if (customSourcesRef.current.includes(src)) return a.source === src;
+        const gameCol = gameCollectionsRef.current.find(c => c.name === src);
+        if (gameCol) return (gameMembershipsRef.current[a.id] || []).includes(gameCol.id);
+        return true; // "All"
       }
-      return a.app_type === "app";
+      if (a.app_type !== "app") return false;
+      const colTab = appCollectionTabRef.current;
+      if (colTab === "All") return true;
+      const col = appCollectionsRef.current.find(c => c.name === colTab);
+      if (!col) return true;
+      return (appMembershipsRef.current[a.id] || []).includes(col.id);
     });
     const fRecent = rec.filter(a =>
       currentTab === "Home" || currentTab === "All" ? true
@@ -2560,6 +2380,9 @@ export default function App() {
         else if (item.type === "attribution") {
           if (item.url) invoke("launch_app", { path: item.url, id: item.key, name: item.label, appType: "app" }).catch(() => {});
         }
+        else if (item.type === "custom_folders") {
+          setShowFolderManager(true); showFolderManagerRef.current = true;
+        }
       }
       if (key === "ArrowLeft") {
         if (!item) return;
@@ -2609,8 +2432,7 @@ export default function App() {
     // Games / Apps tabs
     // LT/RT cycle source sub-tabs on Games tab (from anywhere)
     if (currentTab === "Games") {
-      const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other"];
-      // "Manage" is the last item in the subtab row, index = SOURCES.length (for Games) or 0 (for Apps)
+      const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other", ...customSourcesRef.current, ...gameCollectionsRef.current.map(c => c.name)];
       if (key === "TriggerLeft") {
         const cur = SOURCES.indexOf(gameSourceTabRef.current);
         const next = SOURCES[(cur - 1 + SOURCES.length) % SOURCES.length];
@@ -2630,29 +2452,51 @@ export default function App() {
         playSound(); return;
       }
     }
+    if (currentTab === "Apps") {
+      const APP_COLS = ["All", ...appCollectionsRef.current.map(c => c.name)];
+      if (key === "TriggerLeft") {
+        const cur = APP_COLS.indexOf(appCollectionTabRef.current);
+        const next = APP_COLS[(cur - 1 + APP_COLS.length) % APP_COLS.length];
+        setAppCollectionTab(next); appCollectionTabRef.current = next;
+        setFocusSection("grid"); focusSectionRef.current = "grid";
+        setFocusIndex(0); focusIndexRef.current = 0;
+        playSound(); return;
+      }
+      if (key === "TriggerRight") {
+        const cur = APP_COLS.indexOf(appCollectionTabRef.current);
+        const next = APP_COLS[(cur + 1) % APP_COLS.length];
+        setAppCollectionTab(next); appCollectionTabRef.current = next;
+        setFocusSection("grid"); focusSectionRef.current = "grid";
+        setFocusIndex(0); focusIndexRef.current = 0;
+        playSound(); return;
+      }
+    }
 
-    // subtabs row: source pills + manage button
-    // For Games: indices 0–3 = All/Steam/Xbox/Other, index 4 = "Manage", index 5 = "Restore" (if hidden exist)
-    // For Apps:  index 0 = "Manage", index 1 = "Restore" (if hidden exist)
-    const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other"];
+    // subtabs row: source pills + game collections + add/folder buttons + manage
+    const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other", ...customSourcesRef.current, ...gameCollectionsRef.current.map(c => c.name)];
+    const APP_COLS_NAV = ["All", ...appCollectionsRef.current.map(c => c.name)];
     const subtabItems = currentTab === "Games"
-      ? [...SOURCES, "manage"]
-      : ["manage"];
+      ? [...SOURCES, "add_app", "add_folder", "manage", "collections"]
+      : [...APP_COLS_NAV, "add_app", "add_folder", "manage", "collections"];
+
+    const switchSubtabItem = (item) => {
+      if (item === "add_app" || item === "add_folder" || item === "manage" || item === "collections") return;
+      if (currentTab === "Games") { setGameSourceTab(item); gameSourceTabRef.current = item; }
+      else { setAppCollectionTab(item); appCollectionTabRef.current = item; }
+      setFocusIndex(0); focusIndexRef.current = 0;
+    };
 
     if (section === "subtabs") {
       if (key === "ArrowRight") {
         const ni = Math.min(subtabFocusIndexRef.current + 1, subtabItems.length - 1);
         setSubtabFocusIndex(ni); subtabFocusIndexRef.current = ni;
-        // Auto-switch source if the new focus is a pill
-        const item = subtabItems[ni];
-        if (item !== "manage" && item !== "restore") { setGameSourceTab(item); gameSourceTabRef.current = item; setFocusIndex(0); focusIndexRef.current = 0; }
+        switchSubtabItem(subtabItems[ni]);
         playSound();
       }
       else if (key === "ArrowLeft") {
         const ni = Math.max(subtabFocusIndexRef.current - 1, 0);
         setSubtabFocusIndex(ni); subtabFocusIndexRef.current = ni;
-        const item = subtabItems[ni];
-        if (item !== "manage" && item !== "restore") { setGameSourceTab(item); gameSourceTabRef.current = item; setFocusIndex(0); focusIndexRef.current = 0; }
+        switchSubtabItem(subtabItems[ni]);
         playSound();
       }
       else if (key === "ArrowDown") {
@@ -2662,7 +2506,10 @@ export default function App() {
       }
       else if (key === "Enter") {
         const item = subtabItems[subtabFocusIndexRef.current];
-        if (item === "manage") { openHideModal(); }
+        if (item === "manage")          { openHideModal(); }
+        else if (item === "add_app")    { setAddAppType(tabRef.current === "Games" ? "game" : "app"); setShowFileBrowser("file"); }
+        else if (item === "add_folder") { setAddAppType(tabRef.current === "Games" ? "game" : "app"); setShowFileBrowser("folder"); }
+        else if (item === "collections") { setShowColModal(true); showColModalRef.current = true; }
         // Pills already auto-switched on focus movement — Enter is a no-op for them
       }
       return; // always return — never fall through to grid/pinned launch
@@ -2740,7 +2587,7 @@ export default function App() {
   useEffect(() => {
     const onKey = (e) => {
       // Modal has its own capture-phase keyboard handler — don't double-fire
-      if (showHideModalRef.current) return;
+      if (showHideModalRef.current || showFileBrowserRef.current || pendingFileRef.current) return;
       if (e.key === "Escape") {
         e.preventDefault();
         if (searchOpenRef.current) {
@@ -3401,6 +3248,54 @@ export default function App() {
             <ControllerTestWidget accent={accent} theme={theme} isDark={isDark} glass={glass} />
           </div>
         );
+        if (item.type === "custom_folders") {
+          const gameFolders = customFolders.filter(f => f.app_type === "game");
+          const appFolders  = customFolders.filter(f => f.app_type !== "game");
+          const toggleFolder = (folderId, enabled) => {
+            invoke("toggle_custom_folder", { id: folderId, enabled }).then(() => {
+              setCustomFolders(prev => prev.map(f => f.id === folderId ? { ...f, enabled } : f));
+            });
+          };
+          const deleteFolder = (folderId) => {
+            invoke("remove_custom_folder", { id: folderId }).then(() => {
+              setCustomFolders(prev => prev.filter(f => f.id !== folderId));
+            });
+          };
+          const renderFolderGroup = (folders, groupLabel) => folders.length === 0 ? null : (
+            <div key={groupLabel}>
+              <div style={{ fontSize: 10, fontWeight: 700, color: theme.textFaint, textTransform: "uppercase", letterSpacing: "0.1em", marginBottom: 4, marginTop: 8 }}>{groupLabel}</div>
+              {folders.map(folder => (
+                <div key={folder.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "6px 0", borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.05)"}` }}>
+                  <div style={{ fontSize: 11, color: folder.enabled !== false ? theme.text : theme.textFaint, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {folder.path}
+                  </div>
+                  <div style={{ fontSize: 9, color: theme.textFaint, flexShrink: 0 }}>{folder.source}</div>
+                  <div onClick={() => toggleFolder(folder.id, folder.enabled !== false ? false : true)}
+                    style={{ width: 36, height: 20, borderRadius: 10, background: folder.enabled !== false ? accent.primary : (isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)"), position: "relative", cursor: "pointer", flexShrink: 0 }}>
+                    <div style={{ width: 14, height: 14, borderRadius: "50%", background: "white", position: "absolute", top: 3, left: folder.enabled !== false ? 19 : 3, transition: "left 0.2s", boxShadow: "0 1px 4px rgba(0,0,0,0.3)" }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          );
+          return (
+            <div key={item.key} ref={rowRef} style={{ ...glass, borderRadius: 14, padding: "14px 20px", marginBottom: 8,
+              border: focused ? `1px solid ${accent.glow}0.6)` : `1px solid ${isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)"}`,
+              boxShadow: focused ? `0 0 0 1px ${accent.glow}0.3), 0 0 20px ${accent.glow}0.1)` : "none" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: customFolders.length > 0 ? 4 : 0 }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: focused ? accent.primary : theme.textDim, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                  {item.label}
+                </div>
+                <span style={{ fontSize: 10, color: theme.textFaint }}>↵ {t('grid.manage')}</span>
+              </div>
+              {customFolders.length === 0 && (
+                <div style={{ fontSize: 12, color: theme.textFaint, fontStyle: "italic" }}>{t('settings.noCustomFolders')}</div>
+              )}
+              {renderFolderGroup(gameFolders, t('tabs.games'))}
+              {renderFolderGroup(appFolders, t('tabs.apps'))}
+            </div>
+          );
+        }
         return null;
       })}
     </div>
@@ -3410,11 +3305,9 @@ export default function App() {
   // NOTE: HideModal is defined outside App (above) to prevent re-mounting on every App re-render
   // ─────────────────────────────────────────────────────────────
 
-  const Btn = ({ color, label }) => (
-    <span style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11, color: theme.textDim }}>
-      <span style={{ width: 20, height: 20, borderRadius: "50%", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: "white", background: color, flexShrink: 0 }}>{label[0]}</span>
-      {label.slice(1)}
-    </span>
+  // label format: "A Launch", "B Back" — first char is button, rest is description
+  const Btn = ({ label }) => (
+    <GamepadBtn btn={label[0]} label={label.slice(2)} theme={theme} isDark={isDark} />
   );
 
   // ── Render ────────────────────────────────────────────────────
@@ -3487,6 +3380,189 @@ export default function App() {
         />
       )}
       {showHideModal && <HideModal key="hide-modal" tab={tab} appsRef={appsRef} hiddenRef={hiddenRef} allAppsRef={allAppsRef} closeHideModal={closeHideModal} toggleHidden={toggleHidden} glass={glass} accent={accent} isDark={isDark} theme={theme} />}
+      {showFileBrowser && (
+        <FileBrowser
+          mode={showFileBrowser}
+          glass={glass} accent={accent} theme={theme} isDark={isDark} repeatSpeed={settings.repeat_speed}
+          onSelect={(file) => { setPendingFile(file); setShowFileBrowser(null); }}
+          onClose={() => setShowFileBrowser(null)}
+        />
+      )}
+      {pendingFile && (
+        <AddEntryModal
+          entryFile={pendingFile}
+          mode={pendingFile.is_dir ? "folder" : "app"}
+          appType={addAppType}
+          existingSources={addAppType === "game" ? customSources : []}
+          collections={addAppType === "game" ? gameCollections : appCollections}
+          glass={glass} accent={accent} theme={theme} isDark={isDark} repeatSpeed={settings.repeat_speed}
+          onConfirm={(result, colSelection) => {
+            const wasFolder  = pendingFile?.is_dir;
+            const isGameType = addAppType === "game";
+            setPendingFile(null);
+
+            // Assign a list of app IDs to an existing collection
+            const assignToCollection = (appIds, colId) => {
+              const cmd     = isGameType ? "set_game_memberships" : "set_app_memberships";
+              const setMems = isGameType ? setGameMemberships : setAppMemberships;
+              const memsRef = isGameType ? gameMembershipsRef : appMembershipsRef;
+              appIds.forEach(id => invoke(cmd, { appId: id, collectionIds: [colId] }));
+              setMems(prev => {
+                const updates = Object.fromEntries(appIds.map(id => [id, [colId]]));
+                const n = { ...prev, ...updates };
+                memsRef.current = n;
+                return n;
+              });
+            };
+
+            // Create a new collection (game or app), then assign
+            const createAndAssign = (appIds, name) => {
+              const createCmd = isGameType ? "create_game_collection" : "create_app_collection";
+              const setCols   = isGameType ? setGameCollections : setAppCollections;
+              const colsRef   = isGameType ? gameCollectionsRef : appCollectionsRef;
+              invoke(createCmd, { name }).then(newCol => {
+                setCols(prev => { const n = [...prev, newCol]; colsRef.current = n; return n; });
+                assignToCollection(appIds, newCol.id);
+              });
+            };
+
+            if (wasFolder) {
+              setCustomFolders(prev => [...prev, result]);
+              // get_all_apps rescans all folders; filter by the source tag we just set
+              // on this folder to find which apps it contributed
+              if (colSelection?.colId || colSelection?.newName) {
+                invoke("get_all_apps").then(all => {
+                  const appIds = all
+                    .filter(a => a.source === result.source && a.app_type === result.app_type)
+                    .map(a => a.id);
+                  if (colSelection.colId) assignToCollection(appIds, colSelection.colId);
+                  else                    createAndAssign(appIds, colSelection.newName);
+                });
+              }
+              refreshLibrary();
+              return;
+            }
+
+            // Single entry: track custom source name unless it's a collection name
+            if (isGameType && result.source) {
+              const BUILTIN = new Set(["Steam","Xbox","Bnet","Other","steam","xbox","battlenet","desktop","uwp"]);
+              const isColName = gameCollectionsRef.current.some(c => c.name === result.source);
+              if (!BUILTIN.has(result.source) && !isColName) {
+                setCustomSources(prev => prev.includes(result.source) ? prev : [...prev, result.source]);
+              }
+            }
+            if (result.id) {
+              if (colSelection?.colId)   assignToCollection([result.id], colSelection.colId);
+              else if (colSelection?.newName) createAndAssign([result.id], colSelection.newName);
+            }
+            refreshLibrary();
+          }}
+          onClose={() => setPendingFile(null)}
+        />
+      )}
+      {/* ── Collection assignment picker (right-click → collections) ── */}
+      {colPickerApp && (() => {
+        const isGame = colPickerApp.app_type === "game";
+        const pickerCols = isGame ? gameCollections : appCollections;
+        const pickerMembers = isGame ? gameMemberships : appMemberships;
+        const setPickerMembers = isGame ? setGameMemberships : setAppMemberships;
+        const pickerMembersRef = isGame ? gameMembershipsRef : appMembershipsRef;
+        const memberCmd = isGame ? "set_game_memberships" : "set_app_memberships";
+        return (
+          <ColPickerModal
+            app={colPickerApp}
+            collections={pickerCols}
+            memberships={pickerMembers}
+            onToggle={(col) => {
+              const current = pickerMembersRef.current[colPickerApp.id] || [];
+              const inCol = current.includes(col.id);
+              const newList = inCol ? current.filter(id => id !== col.id) : [...current, col.id];
+              invoke(memberCmd, { appId: colPickerApp.id, collectionIds: newList }).then(() => {
+                setPickerMembers(prev => { const n = { ...prev, [colPickerApp.id]: newList }; pickerMembersRef.current = n; return n; });
+              });
+            }}
+            onClose={() => { setColPickerApp(null); colPickerAppRef.current = null; }}
+            glass={glass} accent={accent} theme={theme} isDark={isDark}
+          />
+        );
+      })()}
+      {/* ── Collection manager modal ── */}
+      {showColModal && (() => {
+        const isGameTab = tab === "Games";
+        return (
+          <CollectionManagerModal
+            key={isGameTab ? "game-col-mgr" : "app-col-mgr"}
+            glass={glass} accent={accent} theme={theme} isDark={isDark}
+            title={t(isGameTab ? 'collections.manageGames' : 'collections.manageApps')}
+            collections={isGameTab ? gameCollections : appCollections}
+            onCreateCollection={(name) => {
+              const cmd = isGameTab ? "create_game_collection" : "create_app_collection";
+              invoke(cmd, { name }).then(col => {
+                if (isGameTab) { setGameCollections(prev => { const n = [...prev, col]; gameCollectionsRef.current = n; return n; }); }
+                else           { setAppCollections(prev => { const n = [...prev, col]; appCollectionsRef.current = n; return n; }); }
+              });
+            }}
+            onDeleteCollection={(id) => {
+              if (isGameTab) {
+                invoke("delete_game_collection", { id }).then(() => {
+                  setGameCollections(prev => { const n = prev.filter(c => c.id !== id); gameCollectionsRef.current = n; return n; });
+                  setGameMemberships(prev => {
+                    const n = { ...prev };
+                    Object.keys(n).forEach(gId => { n[gId] = n[gId].filter(cid => cid !== id); });
+                    gameMembershipsRef.current = n; return n;
+                  });
+                });
+              } else {
+                invoke("delete_app_collection", { id }).then(() => {
+                  setAppCollections(prev => { const n = prev.filter(c => c.id !== id); appCollectionsRef.current = n; return n; });
+                  setAppMemberships(prev => {
+                    const n = { ...prev };
+                    Object.keys(n).forEach(aId => { n[aId] = n[aId].filter(cid => cid !== id); });
+                    appMembershipsRef.current = n; return n;
+                  });
+                  if (appCollectionTab !== "All" && !appCollections.filter(c => c.id !== id).find(c => c.name === appCollectionTab)) {
+                    setAppCollectionTab("All"); appCollectionTabRef.current = "All";
+                  }
+                });
+              }
+            }}
+            onClose={() => { setShowColModal(false); showColModalRef.current = false; }}
+          />
+        );
+      })()}
+      {/* ── Folder manager modal (settings → custom folders → A) ── */}
+      {showFolderManager && (
+        <FolderManagerModal
+          customFolders={customFolders}
+          onToggle={(id, enabled) => {
+            invoke("toggle_custom_folder", { id, enabled }).then(() => {
+              setCustomFolders(prev => prev.map(f => f.id === id ? { ...f, enabled } : f));
+            });
+          }}
+          onDelete={(id) => {
+            invoke("remove_custom_folder", { id }).then(() => {
+              setCustomFolders(prev => prev.filter(f => f.id !== id));
+            });
+          }}
+          glass={glass} accent={accent} theme={theme} isDark={isDark}
+          onClose={() => { setShowFolderManager(false); showFolderManagerRef.current = false; }}
+        />
+      )}
+      {/* ── Confirm delete app modal ── */}
+      {confirmDelete && (
+        <ConfirmModal
+          message={t('confirm.deleteApp', { name: confirmDelete.name })}
+          onConfirm={() => {
+            invoke("remove_custom_app", { id: confirmDelete.id }).then(() => {
+              setApps(prev => prev.filter(a => a.id !== confirmDelete.id));
+              allAppsRef.current = allAppsRef.current.filter(a => a.id !== confirmDelete.id);
+              setConfirmDelete(null); confirmDeleteRef.current = null;
+            });
+          }}
+          onCancel={() => { setConfirmDelete(null); confirmDeleteRef.current = null; }}
+          glass={glass} accent={accent} theme={theme} isDark={isDark}
+        />
+      )}
       {libraryRefreshStatus === "scanning" && (
         <div style={{ position: "fixed", inset: 0, zIndex: 5000, display: "flex", alignItems: "center", justifyContent: "center",
           background: isDark ? "rgba(10,5,2,0.75)" : "rgba(240,230,220,0.75)", backdropFilter: "blur(12px)", WebkitBackdropFilter: "blur(12px)" }}>
@@ -3626,9 +3702,9 @@ export default function App() {
             {searchMode === "results" && (
               <div style={{ position: "sticky", bottom: 0, paddingTop: 8 }}>
                 <div style={{ ...glass, borderRadius: 12, padding: "9px 20px", display: "flex", gap: 16, alignItems: "center" }}>
-                  <Btn color="#4a9c4a" label={t('gamepad.aLaunch')} />
-                  <Btn color="#9a7020" label={t('gamepad.yKeyboard')} />
-                  <Btn color="#b03030" label={t('gamepad.bClose')} />
+                  <Btn label={t('gamepad.aLaunch')} />
+                  <Btn label={t('gamepad.yKeyboard')} />
+                  <Btn label={t('gamepad.bClose')} />
                   <span style={{ marginLeft: "auto", fontSize: 11, color: theme.textFaint }}>↑ from top → Keyboard</span>
                 </div>
               </div>
@@ -3637,8 +3713,8 @@ export default function App() {
             {searchMode === "idle" && (
               <div style={{ position: "sticky", bottom: 0, paddingTop: 8 }}>
                 <div style={{ ...glass, borderRadius: 12, padding: "9px 20px", display: "flex", gap: 16, alignItems: "center" }}>
-                  <Btn color="#9a7020" label={t('gamepad.yKeyboard')} />
-                  <Btn color="#b03030" label={t('gamepad.bClose')} />
+                  <Btn label={t('gamepad.yKeyboard')} />
+                  <Btn label={t('gamepad.bClose')} />
                   {searchResults.length > 0 && <span style={{ fontSize: 11, color: theme.textFaint }}>{t('search.startBrowse')}</span>}
                 </div>
               </div>
@@ -3723,41 +3799,76 @@ export default function App() {
             <div ref={tabScrollRef} style={{ position: "absolute", inset: 0, overflowY: "auto", zIndex: 2 }}>
             <div style={{ padding: "14px 24px 0", ...(settings.wide_layout ? {} : { maxWidth: 1400, margin: "0 auto" }), width: "100%", boxSizing: "border-box" }}>
 
-            {/* ── SOURCE SUB-TABS (Games only) + MANAGE BUTTONS ── */}
+            {/* ── SOURCE SUB-TABS (Games only) + MANAGE + ADD BUTTONS ── */}
             {(() => {
-              const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other"];
+              const SOURCES = ["All", "Steam", "Xbox", "Bnet", "Other", ...customSources, ...gameCollections.map(c => c.name)];
+              const APP_COLS = ["All", ...appCollections.map(c => c.name)];
               const subtabItems = tab === "Games"
-                ? [...SOURCES, "manage"]
-                : ["manage"];
-              const manageIdx  = tab === "Games" ? SOURCES.length : 0;
+                ? [...SOURCES, "add_app", "add_folder", "manage", "collections"]
+                : [...APP_COLS, "add_app", "add_folder", "manage", "collections"];
+              const addAppIdx    = tab === "Games" ? SOURCES.length     : APP_COLS.length;
+              const addFolderIdx = tab === "Games" ? SOURCES.length + 1 : APP_COLS.length + 1;
+              const manageIdx    = tab === "Games" ? SOURCES.length + 2 : APP_COLS.length + 2;
+              const colModalIdx  = tab === "Games" ? SOURCES.length + 3 : APP_COLS.length + 3;
+              const subtabStyle = (active) => ({
+                fontSize: 11, fontWeight: 600, letterSpacing: "0.06em", padding: "5px 14px", borderRadius: 20, cursor: "pointer", transition: "all 0.15s ease",
+                background: active ? accent.primary : (isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)"),
+                color: active ? "white" : theme.textDim,
+                border: `1px solid ${active ? accent.primary : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
+                boxShadow: active ? `0 2px 10px ${accent.glow}0.35)` : "none",
+              });
               return (
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingBottom: 4 }}>
                   {tab === "Games" ? (
-                    <div style={{ display: "flex", gap: 4 }}>
+                    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
                       {SOURCES.map((src, i) => {
-                        const active  = gameSourceTab === src;
+                        const active = gameSourceTab === src;
+                        const isCollection = gameCollections.some(c => c.name === src);
                         return (
                           <div key={src} onClick={() => { setGameSourceTab(src); gameSourceTabRef.current = src; setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(i); subtabFocusIndexRef.current = i; setFocusIndex(0); focusIndexRef.current = 0; }}
-                            style={{ fontSize: 11, fontWeight: 600, letterSpacing: "0.06em", padding: "5px 14px", borderRadius: 20, cursor: "pointer", transition: "all 0.15s ease",
-                              background: active ? accent.primary : (isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)"),
-                              color: active ? "white" : theme.textDim,
-                              border: `1px solid ${active ? accent.primary : (isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)")}`,
-                              boxShadow: active ? `0 2px 10px ${accent.glow}0.35)` : "none",
-                            }}>
+                            style={{ ...subtabStyle(active), ...(isCollection && !active ? { borderStyle: "dashed" } : {}) }}>
                             {src === "All" ? t('sources.all') : src === "Other" ? t('sources.other') : src}
                           </div>
                         );
                       })}
                     </div>
                   ) : (
-                    <div />
+                    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                      {APP_COLS.map((col, i) => {
+                        const active = appCollectionTab === col;
+                        return (
+                          <div key={col} onClick={() => { setAppCollectionTab(col); appCollectionTabRef.current = col; setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(i); subtabFocusIndexRef.current = i; setFocusIndex(0); focusIndexRef.current = 0; }}
+                            style={subtabStyle(active)}>
+                            {col === "All" ? t('sources.all') : col}
+                          </div>
+                        );
+                      })}
+                    </div>
                   )}
-                  <div onClick={() => { openHideModal(); setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(manageIdx); subtabFocusIndexRef.current = manageIdx; }}
-                    style={{ fontSize: 11, fontWeight: 600, padding: "5px 14px", borderRadius: 20, cursor: "pointer", transition: "all 0.15s ease",
-                      color: theme.textDim, background: isDark ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)",
-                      border: `1px solid ${isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)"}`,
-                    }}>
-                    {t('grid.manage')}
+                  <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+                    <div onClick={() => { setAddAppType(tab === "Games" ? "game" : "app"); setShowFileBrowser("file"); setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(addAppIdx); subtabFocusIndexRef.current = addAppIdx; }}
+                      style={{ ...subtabStyle(focusSection === "subtabs" && subtabFocusIndex === addAppIdx), padding: "5px 10px", display: "flex", alignItems: "center", justifyContent: "center" }}
+                      title={tab === "Games" ? t('addEntry.addGame') : t('addEntry.addApp')}>
+                      <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                        <path d="M6.5 1v11M1 6.5h11" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+                      </svg>
+                    </div>
+                    <div onClick={() => { setAddAppType(tab === "Games" ? "game" : "app"); setShowFileBrowser("folder"); setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(addFolderIdx); subtabFocusIndexRef.current = addFolderIdx; }}
+                      style={{ ...subtabStyle(focusSection === "subtabs" && subtabFocusIndex === addFolderIdx), padding: "5px 10px", display: "flex", alignItems: "center", justifyContent: "center" }}
+                      title={t('addEntry.addFolder')}>
+                      <svg width="16" height="13" viewBox="0 0 16 13" fill="none">
+                        <path d="M1 3.5a1 1 0 011-1h3.8l1.4 1.5H14a1 1 0 011 1v6a1 1 0 01-1 1H2a1 1 0 01-1-1V3.5z" stroke="currentColor" strokeWidth="1.2"/>
+                        <path d="M8 6.5v3M6.5 8h3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                      </svg>
+                    </div>
+                    <div onClick={() => { openHideModal(); setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(manageIdx); subtabFocusIndexRef.current = manageIdx; }}
+                      style={subtabStyle(focusSection === "subtabs" && subtabFocusIndex === manageIdx)}>
+                      {t('grid.manage')}
+                    </div>
+                    <div onClick={() => { setShowColModal(true); showColModalRef.current = true; setFocusSection("subtabs"); focusSectionRef.current = "subtabs"; setSubtabFocusIndex(colModalIdx); subtabFocusIndexRef.current = colModalIdx; }}
+                      style={subtabStyle(focusSection === "subtabs" && subtabFocusIndex === colModalIdx)}>
+                      {t('collections.manage')}
+                    </div>
                   </div>
                 </div>
               );
@@ -3901,41 +4012,33 @@ export default function App() {
               : { maxWidth: 1400, margin: "0 auto 14px", width: "calc(100% - 48px)" }),
           }}>
             {tab === "Settings"
-              ? <><Btn color="#4a9c4a" label={t('gamepad.aSelect')} /><Btn color="#b03030" label={t('gamepad.bBack')} /></>
+              ? <><Btn label={t('gamepad.aSelect')} /><Btn label={t('gamepad.bBack')} /></>
               : <>
-                  <Btn color="#4a9c4a" label={t('gamepad.aLaunch')} />
-                  <Btn color="#b03030" label={t('gamepad.bBack')} />
-                  <Btn color="#9a7020" label={t('gamepad.ySearch')} />
-                  <Btn color="#3a5a8a" label={t('gamepad.xPin')} />
+                  <Btn label={t('gamepad.aLaunch')} />
+                  <Btn label={t('gamepad.bBack')} />
+                  <Btn label={t('gamepad.ySearch')} />
+                  <Btn label={t('gamepad.xPin')} />
                   <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                    <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>LB</span>
-                    <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>RB</span>
-                    {t('gamepad.tabs')}
+                    <GamepadBtn btn="LB" label="" theme={theme} isDark={isDark} style={{ gap: 3 }} />
+                    <GamepadBtn btn="RB" label={t('gamepad.tabs')} theme={theme} isDark={isDark} />
                   </span>
                   {tab === "Games" && <>
                     <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                      <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>LT</span>
-                      <span style={{ height: 18, minWidth: 24, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 8, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>RT</span>
-                      {t('gamepad.source')}
+                      <GamepadBtn btn="LT" label="" theme={theme} isDark={isDark} style={{ gap: 3 }} />
+                      <GamepadBtn btn="RT" label={t('gamepad.source')} theme={theme} isDark={isDark} />
                     </span>
-                    <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                      <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>MENU</span>
-                      {t('gamepad.options')}
-                    </span>
-                    <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                      <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>BACK</span>
-                      {t('grid.manage')}
-                    </span>
+                    <GamepadBtn btn="MENU" label={t('gamepad.options')} theme={theme} isDark={isDark} />
+                    <GamepadBtn btn="BACK" label={t('grid.manage')}    theme={theme} isDark={isDark} />
                   </>}
                   {tab === "Apps" && <>
-                    <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                      <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>MENU</span>
-                      {t('gamepad.options')}
-                    </span>
-                    <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
-                      <span style={{ height: 18, minWidth: 28, borderRadius: 4, background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: isDark ? "white" : "#333", padding: "0 4px" }}>BACK</span>
-                      {t('grid.manage')}
-                    </span>
+                    {appCollections.length > 0 && (
+                      <span style={{ display: "flex", alignItems: "center", gap: 5, fontSize: 11, color: theme.textDim }}>
+                        <GamepadBtn btn="LT" label="" theme={theme} isDark={isDark} style={{ gap: 3 }} />
+                        <GamepadBtn btn="RT" label={t('gamepad.source')} theme={theme} isDark={isDark} />
+                      </span>
+                    )}
+                    <GamepadBtn btn="MENU" label={t('gamepad.options')} theme={theme} isDark={isDark} />
+                    <GamepadBtn btn="BACK" label={t('grid.manage')}    theme={theme} isDark={isDark} />
                   </>}
                 </>
             }
@@ -3946,50 +4049,26 @@ export default function App() {
       {contextMenu && (() => {
         const ctxItems = [
           { label: t('contextMenu.open'),      action: () => { triggerLaunch(contextMenu.app, recentRef.current); setContextMenu(null); contextMenuRef.current = null; } },
+          { label: t(hidden.includes(contextMenu.app.id) ? 'contextMenu.show' : 'contextMenu.hide'), action: () => { toggleHidden(contextMenu.app.id); setContextMenu(null); contextMenuRef.current = null; } },
           { label: t(pins.includes(contextMenu.app.id) ? 'contextMenu.unpin' : 'contextMenu.pin'), action: () => { togglePin(contextMenu.app); setContextMenu(null); contextMenuRef.current = null; } },
           { label: t('contextMenu.changeArt'), action: () => { setArtPickerMode("grid"); artPickerModeRef.current = "grid"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } },
           ...(contextMenu.app.app_type === "game"
             ? [{ label: t('contextMenu.changeHeroArt'), action: () => { setArtPickerMode("hero"); artPickerModeRef.current = "hero"; setArtPickerApp(contextMenu.app); artPickerAppRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } }]
             : []),
+          ...((contextMenu.app.app_type === "game" ? gameCollections.length > 0 : appCollections.length > 0)
+            ? [{ label: t('contextMenu.collections'), action: () => { setColPickerApp(contextMenu.app); setContextMenu(null); contextMenuRef.current = null; } }]
+            : []),
+          ...(contextMenu.app.id.startsWith("custom_")
+            ? [{ label: t('contextMenu.delete'), danger: true, action: () => { setConfirmDelete(contextMenu.app); confirmDeleteRef.current = contextMenu.app; setContextMenu(null); contextMenuRef.current = null; } }]
+            : []),
         ];
-        const ctxFocused = contextMenu.focusedIdx || 0;
-        const menuH = ctxItems.length * 52 + 16;
         return (
-          <div style={{ position: "fixed", inset: 0, zIndex: 9000 }}
-            onClick={() => { setContextMenu(null); contextMenuRef.current = null; }}
-            onContextMenu={(e) => { e.preventDefault(); setContextMenu(null); contextMenuRef.current = null; }}>
-            <div onClick={(e) => e.stopPropagation()}
-              style={{ position: "fixed",
-                left: Math.min(contextMenu.x, window.innerWidth - 210),
-                top: Math.min(contextMenu.y, window.innerHeight - menuH),
-                background: isDark ? "rgba(18,12,8,0.98)" : "rgba(255,255,255,0.98)",
-                backdropFilter: "blur(20px)", WebkitBackdropFilter: "blur(20px)",
-                border: `1px solid ${isDark ? "rgba(255,255,255,0.14)" : "rgba(0,0,0,0.14)"}`,
-                borderRadius: 14, overflow: "hidden", minWidth: 200, zIndex: 9001,
-                boxShadow: "0 12px 48px rgba(0,0,0,0.5)", fontFamily: "'Segoe UI', sans-serif" }}>
-              <div style={{ padding: "8px 0" }}>
-                {ctxItems.map(({ label, action }, i) => (
-                  <div key={label} onClick={action}
-                    style={{ padding: "12px 20px", cursor: "pointer", fontSize: 14, fontWeight: 500, color: theme.text,
-                      background: i === ctxFocused ? `${accent.glow}0.18)` : "transparent",
-                      borderLeft: i === ctxFocused ? `3px solid ${accent.primary}` : "3px solid transparent",
-                      transition: "background 0.1s ease" }}
-                    onMouseEnter={(e) => { setContextMenu(prev => { const u = { ...prev, focusedIdx: i }; contextMenuRef.current = u; return u; }); }}
-                    onMouseLeave={(e) => e.currentTarget.style.background = i === ctxFocused ? `${accent.glow}0.18)` : "transparent"}>
-                    {label}
-                  </div>
-                ))}
-              </div>
-              <div style={{ padding: "6px 16px 8px", borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)"}`, display: "flex", gap: 10 }}>
-                {[{ bg: "#4a9c4a", label: t('gamepad.aSelect') }, { bg: "#b03030", label: t('gamepad.bClose') }].map(({ bg, label }) => (
-                  <span key={label} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 10, color: theme.textDim }}>
-                    <span style={{ width: 16, height: 16, borderRadius: "50%", background: bg, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 7, fontWeight: 700, color: "white", flexShrink: 0 }}>{label[0]}</span>
-                    {label.slice(1)}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
+          <ContextMenuModal
+            app={contextMenu.app}
+            items={ctxItems}
+            glass={glass} accent={accent} theme={theme} isDark={isDark}
+            onClose={() => { setContextMenu(null); contextMenuRef.current = null; }}
+          />
         );
       })()}
 

--- a/src/components/FileBrowser.tsx
+++ b/src/components/FileBrowser.tsx
@@ -1,0 +1,311 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
+import { GamepadBtn } from "./GamepadBtn";
+
+function getBestGamepad() {
+  const gps = Array.from(navigator.getGamepads()).filter(Boolean);
+  return (
+    gps.find(gp => gp!.mapping === "standard" && gp!.axes.length >= 4) ||
+    gps.find(gp => gp!.buttons.length >= 4    && gp!.axes.length >= 4) ||
+    gps[0] || null
+  );
+}
+function readGpState(gp: Gamepad) {
+  const btn = (i: number) => !!gp.buttons[i]?.pressed;
+  const hatLeft  = (gp.axes[6] ?? 0) < -0.5;
+  const hatRight = (gp.axes[6] ?? 0) >  0.5;
+  const hatUp    = (gp.axes[7] ?? 0) < -0.5;
+  const hatDown  = (gp.axes[7] ?? 0) >  0.5;
+  return {
+    ArrowUp:    btn(12) || hatUp    || gp.axes[1] < -0.5,
+    ArrowDown:  btn(13) || hatDown  || gp.axes[1] >  0.5,
+    Enter:      btn(0),
+    Escape:     btn(1),
+    ButtonX:    btn(2),
+  };
+}
+
+interface FileEntry {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  extension: string;
+}
+
+interface Props {
+  mode?: "file" | "folder";
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  repeatSpeed?: string;
+  onSelect: (entry: FileEntry) => void;
+  onClose: () => void;
+}
+
+export default function FileBrowser({ mode = "file", glass, accent, theme, isDark, repeatSpeed = "normal", onSelect, onClose }: Props) {
+  const { t } = useTranslation();
+  const [entries, setEntries]   = useState<FileEntry[]>([]);
+  const [path, setPath]         = useState<string | null>(null);
+  const [history, setHistory]   = useState<(string | null)[]>([]);
+  const [focusIdx, setFocusIdx] = useState(0);
+  const focusIdxRef             = useRef(0);
+  const focusedRef              = useRef<HTMLDivElement | null>(null);
+
+  const iDelay = repeatSpeed === "slow" ? 500 : repeatSpeed === "fast" ? 250 : 400;
+  const rDelay = repeatSpeed === "slow" ? 150 : repeatSpeed === "fast" ? 60  : 100;
+
+  const load = useCallback((targetPath: string | null) => {
+    const cmd = targetPath === null ? "get_drives" : "list_dir";
+    const args = targetPath === null ? {} : { path: targetPath };
+    invoke<FileEntry[]>(cmd, args).then(result => {
+      setEntries(result);
+      setFocusIdx(0);
+      focusIdxRef.current = 0;
+    }).catch(() => setEntries([]));
+  }, []);
+
+  useEffect(() => { load(null); }, [load]);
+
+  useEffect(() => {
+    if (focusedRef.current) focusedRef.current.scrollIntoView({ block: "nearest" });
+  }, [focusIdx]);
+
+  const navigate = useCallback((entry: FileEntry) => {
+    if (entry.is_dir) {
+      setHistory(h => [...h, path]);
+      setPath(entry.path);
+      load(entry.path);
+    } else {
+      onSelect(entry);
+    }
+  }, [path, load, onSelect]);
+
+  const goUp = useCallback(() => {
+    if (history.length === 0) { onClose(); return; }
+    const prev = history[history.length - 1] ?? null;
+    setHistory(h => h.slice(0, -1));
+    setPath(prev);
+    load(prev);
+  }, [history, load, onClose]);
+
+  const selectFolder = useCallback(() => {
+    if (path === null) return;
+    onSelect({ name: path.split("\\").pop() || path, path, is_dir: true, extension: "" });
+  }, [path, onSelect]);
+
+  const navigateRef     = useRef(navigate);
+  const goUpRef         = useRef(goUp);
+  const selectFolderRef = useRef(selectFolder);
+  const entriesRef      = useRef(entries);
+  const modeRef         = useRef(mode);
+  const pathRef         = useRef(path);
+  useEffect(() => { navigateRef.current     = navigate; },     [navigate]);
+  useEffect(() => { goUpRef.current         = goUp; },         [goUp]);
+  useEffect(() => { selectFolderRef.current = selectFolder; }, [selectFolder]);
+  useEffect(() => { entriesRef.current      = entries; },      [entries]);
+  useEffect(() => { modeRef.current         = mode; },         [mode]);
+  useEffect(() => { pathRef.current         = path; },         [path]);
+
+  useEffect(() => {
+    const pressTime: any = {};
+    const repeating: any = {};
+
+    const handle = (key: string) => {
+      if (key === "ArrowDown") {
+        const next = Math.min(focusIdxRef.current + 1, entriesRef.current.length - 1);
+        setFocusIdx(next); focusIdxRef.current = next;
+      } else if (key === "ArrowUp") {
+        const next = Math.max(focusIdxRef.current - 1, 0);
+        setFocusIdx(next); focusIdxRef.current = next;
+      } else if (key === "Enter") {
+        const entry = entriesRef.current[focusIdxRef.current];
+        if (entry) navigateRef.current(entry);
+        else if (modeRef.current === "folder" && pathRef.current !== null) selectFolderRef.current();
+      } else if (key === "Escape") {
+        goUpRef.current();
+      } else if (key === "f") {
+        if (modeRef.current === "folder" && pathRef.current !== null) selectFolderRef.current();
+      }
+    };
+
+    const onKey = (e: KeyboardEvent) => {
+      const key = e.key;
+      if (!["ArrowDown","ArrowUp","Enter","Escape","f"].includes(key)) return;
+      e.preventDefault();
+      if (!pressTime[key]) {
+        handle(key);
+        pressTime[key] = Date.now();
+        repeating[key] = false;
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => { delete pressTime[e.key]; delete repeating[e.key]; };
+
+    const rAF = { current: 0 };
+    const tick = () => {
+      const now = Date.now();
+      for (const key of Object.keys(pressTime)) {
+        const held = now - pressTime[key];
+        if (!repeating[key] && held >= iDelay) { repeating[key] = true; pressTime[key] = now; handle(key); }
+        else if (repeating[key] && held >= rDelay) { pressTime[key] = now; handle(key); }
+      }
+      rAF.current = requestAnimationFrame(tick);
+    };
+    rAF.current = requestAnimationFrame(tick);
+    window.addEventListener("keydown", onKey, true);
+    window.addEventListener("keyup", onKeyUp, true);
+    return () => {
+      cancelAnimationFrame(rAF.current);
+      window.removeEventListener("keydown", onKey, true);
+      window.removeEventListener("keyup", onKeyUp, true);
+    };
+  }, [iDelay, rDelay]);
+
+  useEffect(() => {
+    const last: any = {};
+    const gpPress: any = {};
+    const gpRepeat: any = {};
+    const REPEATABLE = new Set(["ArrowUp", "ArrowDown"]);
+    let suppressFrames = 20;
+
+    const handle = (key: string) => {
+      if (key === "ArrowDown") {
+        const next = Math.min(focusIdxRef.current + 1, entriesRef.current.length - 1);
+        setFocusIdx(next); focusIdxRef.current = next;
+      } else if (key === "ArrowUp") {
+        const next = Math.max(focusIdxRef.current - 1, 0);
+        setFocusIdx(next); focusIdxRef.current = next;
+      } else if (key === "Enter") {
+        const entry = entriesRef.current[focusIdxRef.current];
+        if (entry) navigateRef.current(entry);
+        else if (modeRef.current === "folder" && pathRef.current !== null) selectFolderRef.current();
+      } else if (key === "Escape") {
+        goUpRef.current();
+      } else if (key === "ButtonX") {
+        if (modeRef.current === "folder" && pathRef.current !== null) selectFolderRef.current();
+      }
+    };
+
+    let rafId: number;
+    const poll = (now: number) => {
+      if (suppressFrames > 0) { suppressFrames--; requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        const iDelayCur = 400;
+        const rDelayCur = 100;
+        for (const key of Object.keys(state)) {
+          const pressed = (state as any)[key];
+          const was = last[key];
+          if (pressed && !was) {
+            handle(key);
+            gpPress[key] = now;
+            gpRepeat[key] = false;
+          } else if (pressed && was && REPEATABLE.has(key)) {
+            const held = now - (gpPress[key] || now);
+            if (!gpRepeat[key] && held >= iDelayCur) { gpRepeat[key] = true; gpPress[key] = now; handle(key); }
+            else if (gpRepeat[key] && held >= rDelayCur) { gpPress[key] = now; handle(key); }
+          } else if (!pressed && was) {
+            gpPress[key] = 0; gpRepeat[key] = false;
+          }
+          last[key] = pressed;
+        }
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  const pathParts = path ? path.replace(/\\/g, "/").split("/").filter(Boolean) : [];
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 1000,
+      background: "rgba(0,0,0,0.6)", backdropFilter: "blur(8px)",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      fontFamily: "'Segoe UI', sans-serif",
+    }}>
+      <div style={{
+        ...glass, width: 560, maxHeight: "75vh", borderRadius: 20,
+        display: "flex", flexDirection: "column", overflow: "hidden",
+        border: `1px solid ${accent.glow}0.3)`,
+        boxShadow: `0 8px 48px rgba(0,0,0,0.6)`,
+      }}>
+        <div style={{ padding: "16px 20px 12px", borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"}` }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: theme.text, marginBottom: 6 }}>
+            {mode === "folder" ? t("fileBrowser.selectFolder") : t("fileBrowser.selectFile")}
+          </div>
+          <div style={{ fontSize: 11, color: theme.textDim, display: "flex", gap: 4, flexWrap: "wrap", alignItems: "center" }}>
+            <span style={{ cursor: "pointer", color: path === null ? accent.primary : theme.textDim }}
+              onClick={() => { setHistory([]); setPath(null); load(null); }}>
+              {t("fileBrowser.drives")}
+            </span>
+            {pathParts.map((part, i) => (
+              <span key={i} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                <span style={{ color: theme.textFaint }}>›</span>
+                <span style={{ cursor: "pointer", color: i === pathParts.length - 1 ? accent.primary : theme.textDim }}
+                  onClick={() => {
+                    const newPath = pathParts.slice(0, i + 1).join("\\") + (pathParts[0].endsWith(":") && i === 0 ? "\\" : "");
+                    const hist = history.slice(0, history.length - (pathParts.length - 1 - i));
+                    setHistory(hist); setPath(newPath); load(newPath);
+                  }}>
+                  {part}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ overflowY: "auto", flex: 1, padding: "8px 0" }}>
+          {entries.length === 0 && (
+            <div style={{ padding: "24px", textAlign: "center", color: theme.textDim, fontSize: 13 }}>
+              {t("fileBrowser.empty")}
+            </div>
+          )}
+          {entries.map((entry, i) => {
+            const focused = focusIdx === i;
+            return (
+              <div key={entry.path} ref={focused ? focusedRef : null}
+                onClick={() => { setFocusIdx(i); focusIdxRef.current = i; navigate(entry); }}
+                style={{
+                  padding: "9px 20px", cursor: "pointer", display: "flex", alignItems: "center", gap: 10,
+                  background: focused ? `${accent.glow}0.15)` : "transparent",
+                  borderLeft: focused ? `2px solid ${accent.primary}` : "2px solid transparent",
+                  transition: "background 0.1s",
+                }}>
+                <span style={{ fontSize: 16, width: 20, textAlign: "center", flexShrink: 0 }}>
+                  {entry.is_dir ? "📁" : entry.extension === "lnk" ? "🔗" : "⚙️"}
+                </span>
+                <span style={{ fontSize: 13, color: theme.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.name}
+                </span>
+                {entry.is_dir && (
+                  <span style={{ marginLeft: "auto", fontSize: 11, color: theme.textFaint }}>›</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{
+          padding: "12px 20px", borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)"}`,
+          display: "flex", gap: 16, alignItems: "center",
+        }}>
+          <GamepadBtn btn="↑↓" label={t("fileBrowser.navigate")} theme={theme} isDark={isDark} />
+          <GamepadBtn btn="A"  label={mode === "folder" ? t("fileBrowser.open") : t("fileBrowser.select")} theme={theme} isDark={isDark} />
+          {mode === "folder" && path !== null && (
+            <span style={{ cursor: "pointer" }} onClick={selectFolder}>
+              <GamepadBtn btn="X" label={t("fileBrowser.selectThis")} theme={theme} isDark={isDark}
+                style={{ color: accent.primary }} />
+            </span>
+          )}
+          <span style={{ marginLeft: "auto", cursor: "pointer" }} onClick={goUp}>
+            <GamepadBtn btn="B" label={t("common.back")} theme={theme} isDark={isDark} />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GamepadBtn.tsx
+++ b/src/components/GamepadBtn.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties } from "react";
+import { TbArrowsUpDown, TbArrowsLeftRight } from "react-icons/tb";
+
+const CIRCLE_COLORS: Record<string, string> = {
+  A: "#4a9c4a",
+  B: "#b03030",
+  X: "#3a5a8a",
+  Y: "#8a6a00",
+};
+
+const PILL_BTNS = new Set(["LB", "RB", "LT", "RT", "MENU", "BACK", "START", "⊞"]);
+
+interface Props {
+  btn: string;
+  label: string;
+  theme: any;
+  isDark?: boolean;
+  style?: CSSProperties;
+}
+
+export function GamepadBtn({ btn, label, theme, isDark = true, style }: Props) {
+  const circleColor = CIRCLE_COLORS[btn];
+  const isPill = PILL_BTNS.has(btn);
+
+  let badge: React.ReactNode;
+
+  if (circleColor) {
+    badge = (
+      <span style={{
+        width: 20, height: 20, borderRadius: "50%",
+        background: circleColor,
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        fontSize: 8, fontWeight: 700, color: "white", flexShrink: 0,
+      }}>
+        {btn}
+      </span>
+    );
+  } else if (isPill) {
+    badge = (
+      <span style={{
+        height: 18,
+        minWidth: btn.length > 2 ? 28 : 24,
+        borderRadius: 4,
+        background: isDark ? "rgba(255,255,255,0.52)" : "rgba(0,0,0,0.15)",
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        fontSize: btn.length > 2 ? 7 : 8, fontWeight: 700,
+        color: isDark ? "white" : "#333",
+        padding: "0 4px", flexShrink: 0,
+      }}>
+        {btn}
+      </span>
+    );
+  } else if (btn === "↑↓") {
+    badge = <TbArrowsUpDown size={14} color={theme.textDim} style={{ flexShrink: 0 }} />;
+  } else if (btn === "←→") {
+    badge = <TbArrowsLeftRight size={14} color={theme.textDim} style={{ flexShrink: 0 }} />;
+  } else {
+    badge = (
+      <span style={{ fontSize: 10, color: theme.textDim, fontWeight: 600, flexShrink: 0 }}>
+        {btn}
+      </span>
+    );
+  }
+
+  return (
+    <span style={{ display: "flex", alignItems: "center", gap: 7, fontSize: 11, color: theme.textDim, ...style }}>
+      {badge}
+      {label}
+    </span>
+  );
+}

--- a/src/components/GamepadKeyboard.tsx
+++ b/src/components/GamepadKeyboard.tsx
@@ -1,0 +1,197 @@
+import { useState, useRef, useEffect } from "react";
+import { getBestGamepad, readGpState } from "../utils/gamepad";
+
+const KB_ALPHA = [
+  ["q","w","e","r","t","y","u","i","o","p"],
+  ["a","s","d","f","g","h","j","k","l"],
+  ["z","x","c","v","b","n","m"],
+];
+const KB_NUMS = [
+  ["1","2","3","4","5","6","7","8","9","0"],
+  ["-","_","=","+","[","]","{","}","\\","|"],
+  [";","'",",",".","!","@","#","$","%","^"],
+];
+const ROW_OFFSETS = [0, 0.5, 1.5];
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  onConfirm?: () => void;
+  title?: string;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  glass: any;
+}
+
+export default function GamepadKeyboard({ value, onChange, onClose, onConfirm, title = "", accent, theme, isDark, glass }: Props) {
+  const [row,     setRow]     = useState(0);
+  const [col,     setCol]     = useState(0);
+  const [numMode, setNumMode] = useState(false);
+
+  const rowRef     = useRef(0);
+  const colRef     = useRef(0);
+  const numModeRef = useRef(false);
+  const valueRef   = useRef(value);
+  useEffect(() => { valueRef.current = value; }, [value]);
+
+  const layout = numMode ? KB_NUMS : KB_ALPHA;
+
+  const fireKey    = (k: string) => onChange(valueRef.current + k);
+  const deleteChar = ()          => onChange(valueRef.current.slice(0, -1));
+  const addSpace   = ()          => onChange(valueRef.current + " ");
+  const toggleNum  = () => {
+    const next = !numModeRef.current;
+    setNumMode(next); numModeRef.current = next;
+    setRow(0); rowRef.current = 0;
+    setCol(0); colRef.current = 0;
+  };
+
+  useEffect(() => {
+    const last: any = {};
+    const pressTime: any = {};
+    const repeating: any = {};
+    const REPEATABLE = new Set(["ArrowUp","ArrowDown","ArrowLeft","ArrowRight","ButtonX"]);
+    const iDelay = 350;
+    const rDelay = 80;
+
+    const handle = (key: string) => {
+      const lay = numModeRef.current ? KB_NUMS : KB_ALPHA;
+      const curRow = rowRef.current;
+      const curCol = colRef.current;
+      const rowLen = lay[curRow]?.length ?? 0;
+
+      if (key === "ArrowRight") {
+        const ni = Math.min(curCol + 1, rowLen - 1);
+        setCol(ni); colRef.current = ni;
+      } else if (key === "ArrowLeft") {
+        const ni = Math.max(curCol - 1, 0);
+        setCol(ni); colRef.current = ni;
+      } else if (key === "ArrowDown") {
+        if (curRow < lay.length - 1) {
+          const nr = curRow + 1;
+          const nc = Math.min(curCol, lay[nr].length - 1);
+          setRow(nr); rowRef.current = nr;
+          setCol(nc); colRef.current = nc;
+        }
+      } else if (key === "ArrowUp") {
+        if (curRow > 0) {
+          const nr = curRow - 1;
+          const nc = Math.min(curCol, lay[nr].length - 1);
+          setRow(nr); rowRef.current = nr;
+          setCol(nc); colRef.current = nc;
+        }
+      } else if (key === "Enter") {
+        const k = lay[curRow]?.[curCol];
+        if (k) fireKey(k);
+      } else if (key === "ButtonX") {
+        deleteChar();
+      } else if (key === "ButtonY") {
+        addSpace();
+      } else if (key === "TriggerRight") {
+        toggleNum();
+      } else if (key === "Escape") {
+        onClose();
+      }
+    };
+
+    let rafId: number;
+    let suppressFrames = 20;
+    const poll = (now: number) => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        for (const key of Object.keys(state)) {
+          const pressed = (state as any)[key];
+          const was = last[key];
+          if (pressed && !was) {
+            handle(key);
+            pressTime[key] = now;
+            repeating[key] = false;
+          } else if (pressed && was && REPEATABLE.has(key)) {
+            const held = now - (pressTime[key] || now);
+            if (!repeating[key] && held >= iDelay) { repeating[key] = true; pressTime[key] = now; handle(key); }
+            else if (repeating[key] && held >= rDelay) { pressTime[key] = now; handle(key); }
+          } else if (!pressed && was) {
+            pressTime[key] = 0; repeating[key] = false;
+          }
+          last[key] = pressed;
+        }
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 3000,
+      background: "rgba(0,0,0,0.7)", backdropFilter: "blur(12px)",
+      display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+      fontFamily: "'Segoe UI', sans-serif",
+    }}>
+      <div style={{ ...glass, borderRadius: 20, padding: "20px 24px", width: 520, display: "flex", flexDirection: "column", gap: 14,
+        border: `1px solid ${accent.glow}0.3)`, boxShadow: "0 12px 60px rgba(0,0,0,0.7)" }}>
+
+        {title && <div style={{ fontSize: 12, fontWeight: 600, color: theme.textDim, textTransform: "uppercase", letterSpacing: "0.08em" }}>{title}</div>}
+
+        <div style={{ background: isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)", borderRadius: 10, padding: "10px 14px",
+          fontSize: 15, color: theme.text, minHeight: 40, letterSpacing: "0.02em",
+          border: `1px solid ${accent.glow}0.25)` }}>
+          {value || <span style={{ color: theme.textFaint, fontStyle: "italic" }}>…</span>}
+          <span style={{ display: "inline-block", width: 2, height: "1em", background: accent.primary, marginLeft: 2, verticalAlign: "text-bottom", animation: "kbCursor 1s steps(1) infinite" }} />
+        </div>
+
+        <div>
+          {layout.map((rowKeys, rIdx) => (
+            <div key={rIdx} style={{ display: "flex", gap: 4, justifyContent: "center", marginBottom: 4,
+              paddingLeft: `${ROW_OFFSETS[rIdx] * 25}px` }}>
+              {rowKeys.map((k, cIdx) => {
+                const active = row === rIdx && col === cIdx;
+                return (
+                  <div key={k + cIdx} onClick={() => { fireKey(k); }}
+                    style={{
+                      width: 44, height: 38, display: "flex", alignItems: "center", justifyContent: "center",
+                      borderRadius: 7, cursor: "pointer", userSelect: "none", flexShrink: 0,
+                      fontSize: 14, fontWeight: active ? 700 : 500,
+                      background: active ? `linear-gradient(135deg, ${accent.primary}, ${accent.dark})` : (isDark ? "rgba(255,255,255,0.07)" : "rgba(255,255,255,0.8)"),
+                      color: active ? "white" : theme.text,
+                      border: active ? `1px solid ${accent.glow}0.7)` : `1px solid ${isDark ? "rgba(255,255,255,0.09)" : "rgba(0,0,0,0.08)"}`,
+                      boxShadow: active ? `0 0 14px ${accent.glow}0.5)` : "none",
+                      transform: active ? "scale(1.14)" : "scale(1)",
+                      transition: "transform 0.07s, box-shadow 0.07s",
+                    }}>
+                    {k}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "center", gap: 14, paddingTop: 4, borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}` }}>
+          {[
+            { bg: "#4a9c4a", label: "A", desc: "Type" },
+            { bg: "#3a5a8a", label: "X", desc: "Delete" },
+            { bg: "#9a7020", label: "Y", desc: "Space" },
+            { bg: "#b03030", label: "B", desc: "Done" },
+            { bg: isDark ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.18)", label: "RT", desc: numMode ? "ABC" : "123", circle: false },
+          ].map(({ bg, label, desc, circle = true }) => (
+            <div key={label} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <div style={{ width: circle ? 18 : "auto", height: 18, minWidth: 18, borderRadius: circle ? "50%" : 4,
+                background: bg, display: "flex", alignItems: "center", justifyContent: "center",
+                fontSize: 8, fontWeight: 700, color: "white", padding: circle ? 0 : "0 3px", flexShrink: 0 }}>
+                {label}
+              </div>
+              <span style={{ fontSize: 10, color: theme.textDim }}>{desc}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <style>{`@keyframes kbCursor { 0%,100%{opacity:1} 50%{opacity:0} }`}</style>
+    </div>
+  );
+}

--- a/src/components/modals/AddEntryModal.tsx
+++ b/src/components/modals/AddEntryModal.tsx
@@ -1,0 +1,311 @@
+import { useState, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
+import GamepadKeyboard from "../GamepadKeyboard";
+import ModalShell from "./ModalShell";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+
+// Built-in game sources (shown as filter tabs in Games, cannot be deleted)
+export const BUILTIN_GAME_SOURCES = ["Steam", "Xbox", "Bnet"];
+
+const SECTION_NAME   = 0;
+const SECTION_PICKER = 1;
+
+export type PickerOption =
+  | { kind: "src";  value: string }
+  | { kind: "col";  id: string; name: string }
+  | { kind: "new" };
+
+interface EntryFile { name: string; path: string; is_dir?: boolean; }
+interface Collection { id: string; name: string; }
+
+interface Props {
+  entryFile: EntryFile;
+  mode: "folder" | "app";
+  appType?: "game" | "app";
+  existingSources?: string[];
+  collections?: Collection[];
+  glass: any; accent: any; theme: any; isDark: boolean;
+  onConfirm: (result: any, colSelection: { colId?: string; newName?: string | null }) => void;
+  onClose: () => void;
+}
+
+export default function AddEntryModal({
+  entryFile, mode, appType = "game",
+  existingSources = [], collections = [],
+  glass, accent, theme, isDark,
+  onConfirm, onClose,
+}: Props) {
+  const { t } = useTranslation();
+  const isFolderMode = mode === "folder";
+  const isGame       = appType === "game";
+
+  const [name, setName]               = useState(() => entryFile.name.replace(/\.(exe|lnk)$/i, ""));
+  const [saving, setSaving]           = useState(false);
+  const [picked, setPicked]           = useState<PickerOption | null>(null);
+  const [newColName, setNewColName]   = useState("");
+  const [gpSection, setGpSection]     = useState(isFolderMode ? SECTION_PICKER : SECTION_NAME);
+  const [gpPickIdx, setGpPickIdx]     = useState(0);
+  const [showKeyboard, setShowKeyboard] = useState(false);
+  const [keyboardField, setKeyboardField] = useState<"name" | "new_col">("name");
+
+  const gpSectionRef    = useRef(isFolderMode ? SECTION_PICKER : SECTION_NAME);
+  const gpPickIdxRef    = useRef(0);
+  const showKeyboardRef = useRef(false);
+  const pickedRef       = useRef<PickerOption | null>(null);
+  const newColNameRef   = useRef("");
+  const nameRef         = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { showKeyboardRef.current = showKeyboard; }, [showKeyboard]);
+  useEffect(() => { pickedRef.current = picked; }, [picked]);
+  useEffect(() => { newColNameRef.current = newColName; }, [newColName]);
+
+  useEffect(() => {
+    if (!isFolderMode && nameRef.current) nameRef.current.focus();
+  }, [isFolderMode]);
+
+  // Games: builtin sources + user-defined sources + user collections + "new"
+  // Apps:  user collections + "new"
+  // Same options regardless of whether it's a folder scan or a single add.
+  const pickerOptions: PickerOption[] = isGame
+    ? [
+        ...BUILTIN_GAME_SOURCES.map(v => ({ kind: "src" as const, value: v })),
+        ...existingSources.map(v => ({ kind: "src" as const, value: v })),
+        ...collections.map(c => ({ kind: "col" as const, id: c.id, name: c.name })),
+        { kind: "new" as const },
+      ]
+    : [
+        ...collections.map(c => ({ kind: "col" as const, id: c.id, name: c.name })),
+        { kind: "new" as const },
+      ];
+
+  const pickerOptionsRef = useRef(pickerOptions);
+  useEffect(() => { pickerOptionsRef.current = pickerOptions; });
+
+  const confirmFnRef = useRef<() => void>(() => {});
+  const confirm = () => {
+    if (saving) return;
+    setSaving(true);
+    const sel = pickedRef.current;
+
+    // For folder scans: the source tag stored on the folder is how we later
+    // identify which apps came from it so we can assign collection memberships.
+    // For single adds: source only matters for BUILTIN (steam/xbox/bnet) picks;
+    // collection assignment is handled via membership, not source.
+    const src = isFolderMode
+      ? (sel?.kind === "src" ? sel.value
+       : sel?.kind === "col" ? sel.name
+       : sel?.kind === "new" ? (newColNameRef.current.trim() || "Other")
+       : "Other")
+      : (sel?.kind === "src" ? sel.value : "Other");
+
+    const cmd  = isFolderMode ? "add_custom_folder" : "add_custom_app";
+    const args = isFolderMode
+      ? { path: entryFile.path, source: src, appType }
+      : { name, path: entryFile.path, appType, source: src };
+
+    invoke(cmd, args)
+      .then(result => {
+        const colSel = sel?.kind === "col" ? { colId: sel.id }
+                     : sel?.kind === "new" ? { newName: newColNameRef.current.trim() || null }
+                     : {};
+        onConfirm(result, colSel);
+      })
+      .catch(() => setSaving(false));
+  };
+  useEffect(() => { confirmFnRef.current = confirm; });
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+    const FIRST = isFolderMode ? SECTION_PICKER : SECTION_NAME;
+
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      const state: any = gp ? readGpState(gp) : {};
+      if (showKeyboardRef.current) { if (gp) Object.assign(last, state); rafId = requestAnimationFrame(poll); return; }
+
+      if (gp) {
+        if (state.Escape && !last.Escape) { onClose(); }
+        if (state.Start  && !last.Start)  { confirmFnRef.current(); }
+
+        if (state.ArrowDown && !last.ArrowDown && gpSectionRef.current < SECTION_PICKER) {
+          const next = gpSectionRef.current + 1;
+          setGpSection(next); gpSectionRef.current = next;
+          nameRef.current?.blur();
+        }
+        if (state.ArrowUp && !last.ArrowUp && gpSectionRef.current > FIRST) {
+          const next = gpSectionRef.current - 1;
+          setGpSection(next); gpSectionRef.current = next;
+          if (next === SECTION_NAME) nameRef.current?.focus();
+        }
+
+        if (gpSectionRef.current === SECTION_NAME && state.Enter && !last.Enter) {
+          setKeyboardField("name"); setShowKeyboard(true); showKeyboardRef.current = true;
+        }
+
+        if (gpSectionRef.current === SECTION_PICKER) {
+          const opts = pickerOptionsRef.current;
+          const setOpt = (opt: PickerOption) => {
+            const v: PickerOption = opt.kind === "new" ? { kind: "new" } : opt;
+            setPicked(v); pickedRef.current = v;
+          };
+          if (state.ArrowRight && !last.ArrowRight) {
+            const next = Math.min(gpPickIdxRef.current + 1, opts.length - 1);
+            setGpPickIdx(next); gpPickIdxRef.current = next;
+            setOpt(opts[next]);
+          }
+          if (state.ArrowLeft && !last.ArrowLeft) {
+            const next = Math.max(gpPickIdxRef.current - 1, 0);
+            setGpPickIdx(next); gpPickIdxRef.current = next;
+            setOpt(opts[next]);
+          }
+          if (state.Enter && !last.Enter) {
+            const opt = opts[gpPickIdxRef.current];
+            if (opt?.kind === "new") {
+              setOpt(opt);
+              setKeyboardField("new_col"); setShowKeyboard(true); showKeyboardRef.current = true;
+            } else if (opt) {
+              setOpt(opt);
+            }
+          }
+        }
+
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isPickFocused = (i: number) => gpSection === SECTION_PICKER && gpPickIdx === i;
+
+  const pillStyle = (active: boolean, focused: boolean): any => ({
+    padding: "5px 12px", borderRadius: 8, cursor: "pointer", fontSize: 12, fontWeight: 500,
+    background: active
+      ? accent.primary
+      : focused
+        ? (isDark ? "rgba(255,255,255,0.12)" : "rgba(0,0,0,0.1)")
+        : (isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)"),
+    color: active ? "white" : theme.text,
+    border: focused ? `1px solid ${accent.primary}` : `1px solid ${active ? accent.primary : "transparent"}`,
+    boxShadow: focused ? `0 0 0 2px ${accent.glow}0.25)` : "none",
+    transition: "all 0.15s",
+  });
+
+  const isActive = (opt: PickerOption) => {
+    if (!picked) return false;
+    if (opt.kind === "src" && picked.kind === "src") return opt.value === picked.value;
+    if (opt.kind === "col" && picked.kind === "col") return opt.id === picked.id;
+    if (opt.kind === "new" && picked.kind === "new") return true;
+    return false;
+  };
+
+  const sectionActive = gpSection === SECTION_PICKER;
+
+  const shortcuts = showKeyboard ? [] : [
+    ...(gpSection === SECTION_PICKER ? [{ btn: "←→", label: t("shortcuts.select") }] : []),
+    { btn: "MENU", label: t("common.add") },
+    { btn: "B",   label: t("common.cancel") },
+  ];
+
+  const modalTitle = isFolderMode
+    ? t("addEntry.addFolder")
+    : isGame ? t("addEntry.addGame") : t("addEntry.addApp");
+
+  return (
+    <>
+      <ModalShell
+        title={modalTitle} shortcuts={shortcuts}
+        glass={glass} accent={accent} theme={theme} isDark={isDark}
+        width={480} zIndex={1001}
+      >
+        <div style={{ padding: "16px 28px", display: "flex", flexDirection: "column", gap: 18 }}>
+
+          <div>
+            <div style={{ fontSize: 11, color: theme.textDim, marginBottom: 4 }}>{t("addEntry.path")}</div>
+            <div style={{ fontSize: 12, color: theme.textFaint, background: isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.05)", borderRadius: 8, padding: "8px 12px", wordBreak: "break-all" }}>
+              {entryFile.path}
+            </div>
+          </div>
+
+          {!isFolderMode && (
+            <div>
+              <div style={{ fontSize: 11, color: gpSection === SECTION_NAME ? accent.primary : theme.textDim, marginBottom: 8, fontWeight: gpSection === SECTION_NAME ? 700 : 400, transition: "color 0.15s" }}>
+                {t("addEntry.name")}
+              </div>
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => { if (e.key === "Escape") onClose(); }}
+                onFocus={() => { setGpSection(SECTION_NAME); gpSectionRef.current = SECTION_NAME; }}
+                style={{
+                  width: "100%", boxSizing: "border-box", padding: "8px 12px",
+                  background: isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)",
+                  border: `1px solid ${gpSection === SECTION_NAME ? accent.primary : `${accent.glow}0.3)`}`,
+                  borderRadius: 8, color: theme.text, fontSize: 13, outline: "none", transition: "border-color 0.15s",
+                }}
+              />
+            </div>
+          )}
+
+          <div>
+            <div style={{ fontSize: 11, color: sectionActive ? accent.primary : theme.textDim, marginBottom: 8, fontWeight: sectionActive ? 700 : 400, transition: "color 0.15s" }}>
+              {t("addEntry.collection")}
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: picked?.kind === "new" ? 8 : 0 }}>
+              {pickerOptions.map((opt, i) => {
+                const label = opt.kind === "src" ? opt.value
+                            : opt.kind === "col" ? opt.name
+                            : `+ ${t("addEntry.newCollection")}`;
+                return (
+                  <button
+                    key={i}
+                    onClick={() => {
+                      setGpSection(SECTION_PICKER); gpSectionRef.current = SECTION_PICKER;
+                      setGpPickIdx(i); gpPickIdxRef.current = i;
+                      const v: PickerOption = opt.kind === "new" ? { kind: "new" } : opt;
+                      setPicked(v); pickedRef.current = v;
+                    }}
+                    style={pillStyle(isActive(opt), isPickFocused(i))}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            {picked?.kind === "new" && (
+              <input
+                value={newColName}
+                onChange={e => setNewColName(e.target.value)}
+                onKeyDown={e => { if (e.key === "Escape") onClose(); }}
+                placeholder={t("addEntry.newCollectionPlaceholder")}
+                style={{
+                  width: "100%", boxSizing: "border-box", padding: "8px 12px",
+                  background: isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.07)",
+                  border: `1px solid ${sectionActive ? accent.primary : `${accent.glow}0.3)`}`,
+                  borderRadius: 8, color: theme.text, fontSize: 13, outline: "none", transition: "border-color 0.15s",
+                }}
+              />
+            )}
+          </div>
+
+        </div>
+      </ModalShell>
+
+      {showKeyboard && (
+        <GamepadKeyboard
+          value={keyboardField === "name" ? name : newColName}
+          onChange={val => { if (keyboardField === "name") setName(val); else setNewColName(val); }}
+          onClose={() => { setShowKeyboard(false); showKeyboardRef.current = false; }}
+          title={keyboardField === "name" ? t("addEntry.name") : t("addEntry.newCollection")}
+          accent={accent} theme={theme} isDark={isDark} glass={glass}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/modals/ColPickerModal.tsx
+++ b/src/components/modals/ColPickerModal.tsx
@@ -1,0 +1,119 @@
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ModalShell from "./ModalShell";
+
+interface Collection {
+  id: string;
+  name: string;
+}
+
+interface App {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  app: App;
+  collections: Collection[];
+  memberships: Record<string, string[]>;
+  onToggle: (col: Collection) => void;
+  onClose: () => void;
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+}
+
+export default function ColPickerModal({ app, collections, memberships, onToggle, onClose, glass, accent, theme, isDark }: Props) {
+  const { t } = useTranslation();
+  const [focusIdx, setFocusIdx] = useState(0);
+  const focusIdxRef = useRef(0);
+  const colsRef     = useRef(collections);
+  useEffect(() => { colsRef.current = collections; }, [collections]);
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        const total = colsRef.current.length;
+        if (state.ArrowDown && !last.ArrowDown) {
+          const next = Math.min(focusIdxRef.current + 1, total - 1);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.ArrowUp && !last.ArrowUp) {
+          const next = Math.max(focusIdxRef.current - 1, 0);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.Enter && !last.Enter) {
+          const col = colsRef.current[focusIdxRef.current];
+          if (col) onToggle(col);
+        }
+        if (state.Escape && !last.Escape) { onClose(); }
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shortcuts = [
+    { btn: "A",  label: t("shortcuts.toggle") },
+    { btn: "B",  label: t("common.close") },
+  ];
+
+  return (
+    <ModalShell
+      title={t("collections.assign", { name: app.name })}
+      shortcuts={shortcuts}
+      glass={glass} accent={accent} theme={theme} isDark={isDark}
+      width={380}
+      zIndex={2000}
+      onOverlayClick={onClose}
+    >
+      <div style={{ padding: "12px 20px", display: "flex", flexDirection: "column", gap: 6 }}>
+        {collections.length === 0
+          ? <div style={{ fontSize: 13, color: theme.textFaint, fontStyle: "italic" }}>{t("collections.none")}</div>
+          : collections.map((col, i) => {
+              const members = memberships[app.id] || [];
+              const inCol   = members.includes(col.id);
+              const focused = focusIdx === i;
+              return (
+                <div
+                  key={col.id}
+                  onClick={() => onToggle(col)}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 12,
+                    cursor: "pointer", padding: "8px 10px", borderRadius: 10,
+                    border: focused ? `2px solid ${accent.primary}` : "2px solid transparent",
+                    background: focused ? (isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.04)") : "transparent",
+                    transition: "all 0.12s",
+                  }}>
+                  <div style={{
+                    width: 20, height: 20, borderRadius: 5,
+                    border: `2px solid ${inCol ? accent.primary : theme.textFaint}`,
+                    background: inCol ? accent.primary : "transparent",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    transition: "all 0.15s", flexShrink: 0,
+                  }}>
+                    {inCol && (
+                      <svg width="12" height="9" viewBox="0 0 12 9" fill="none">
+                        <path d="M1 4l4 4L11 1" stroke="white" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    )}
+                  </div>
+                  <span style={{ fontSize: 13, color: theme.text }}>{col.name}</span>
+                </div>
+              );
+            })
+        }
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/components/modals/CollectionManagerModal.tsx
+++ b/src/components/modals/CollectionManagerModal.tsx
@@ -1,0 +1,202 @@
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ConfirmModal from "./ConfirmModal";
+import GamepadKeyboard from "../GamepadKeyboard";
+import ModalShell from "./ModalShell";
+
+interface Collection {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  collections: Collection[];
+  onCreateCollection: (name: string) => void;
+  onDeleteCollection: (id: string) => void;
+  onClose: () => void;
+  title?: string;
+}
+
+export default function CollectionManagerModal({ glass, accent, theme, isDark, collections, onCreateCollection, onDeleteCollection, onClose, title }: Props) {
+  const { t } = useTranslation();
+  const [showKb, setShowKb]                     = useState(false);
+  const [kbValue, setKbValue]                   = useState("");
+  const [confirmDeleteCol, setConfirmDeleteCol] = useState<Collection | null>(null);
+  const [focusIdx, setFocusIdx]                 = useState(0);
+
+  const focusIdxRef             = useRef(0);
+  const colsRef                 = useRef(collections);
+  const showKbRef               = useRef(false);
+  const kbValueRef              = useRef("");
+  const confirmDeleteColRef     = useRef<Collection | null>(null);
+  const onCreateCollectionRef   = useRef(onCreateCollection);
+  const onDeleteCollectionRef   = useRef(onDeleteCollection);
+
+  useEffect(() => { colsRef.current = collections; },                  [collections]);
+  useEffect(() => { showKbRef.current = showKb; },                     [showKb]);
+  useEffect(() => { kbValueRef.current = kbValue; },                   [kbValue]);
+  useEffect(() => { confirmDeleteColRef.current = confirmDeleteCol; }, [confirmDeleteCol]);
+  useEffect(() => { onCreateCollectionRef.current = onCreateCollection; }, [onCreateCollection]);
+  useEffect(() => { onDeleteCollectionRef.current = onDeleteCollection; }, [onDeleteCollection]);
+
+  // total = collections + 1 "add" row
+  const totalRows = () => colsRef.current.length + 1;
+  const isAddRow  = (i: number) => i === colsRef.current.length;
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (showKbRef.current || confirmDeleteColRef.current) {
+        // keep tracking state so resumed polling doesn't re-fire held buttons
+        if (gp) Object.assign(last, readGpState(gp));
+        rafId = requestAnimationFrame(poll); return;
+      }
+      if (gp) {
+        const state = readGpState(gp);
+        if (state.ArrowDown && !last.ArrowDown) {
+          const next = Math.min(focusIdxRef.current + 1, totalRows() - 1);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.ArrowUp && !last.ArrowUp) {
+          const next = Math.max(focusIdxRef.current - 1, 0);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.Enter && !last.Enter) {
+          const i = focusIdxRef.current;
+          if (isAddRow(i)) {
+            setShowKb(true); showKbRef.current = true;
+          }
+        }
+        if (state.ButtonX && !last.ButtonX) {
+          const i = focusIdxRef.current;
+          const col = colsRef.current[i];
+          if (col) { setConfirmDeleteCol(col); confirmDeleteColRef.current = col; }
+        }
+        if (state.Escape && !last.Escape) { onClose(); }
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const onColRow = focusIdx < collections.length;
+
+  const shortcuts = [
+    ...(onColRow ? [{ btn: "X", label: t("common.delete") }] : [{ btn: "A", label: t("common.add") }]),
+    { btn: "B", label: t("common.close") },
+  ];
+
+  return (
+    <>
+      <ModalShell
+        title={title || t("collections.manage")}
+        shortcuts={shortcuts}
+        glass={glass} accent={accent} theme={theme} isDark={isDark}
+        width={320}
+        zIndex={2000}
+        onOverlayClick={onClose}
+      >
+        <div style={{ padding: "8px 0" }}>
+          {collections.map((col, i) => {
+            const focused = focusIdx === i;
+            return (
+              <div
+                key={col.id}
+                onClick={() => {
+                  if (focusIdxRef.current === i) {
+                    setConfirmDeleteCol(col); confirmDeleteColRef.current = col;
+                  } else {
+                    setFocusIdx(i); focusIdxRef.current = i;
+                  }
+                }}
+                onMouseEnter={() => { setFocusIdx(i); focusIdxRef.current = i; }}
+                style={{
+                  padding: "12px 24px",
+                  cursor: "pointer",
+                  fontSize: 14,
+                  fontWeight: 500,
+                  color: theme.text,
+                  background: focused
+                    ? (isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.05)")
+                    : "transparent",
+                  borderLeft: `3px solid ${focused ? accent.primary : "transparent"}`,
+                  transition: "background 0.1s, border-color 0.1s",
+                }}
+              >
+                <span>{col.name}</span>
+              </div>
+            );
+          })}
+
+          {collections.length === 0 && (
+            <div style={{ padding: "8px 24px 4px", fontSize: 13, color: theme.textFaint, fontStyle: "italic" }}>
+              {t("collections.empty")}
+            </div>
+          )}
+
+          {/* Add row */}
+          <div
+            onClick={() => { setShowKb(true); showKbRef.current = true; }}
+            onMouseEnter={() => { const i = collections.length; setFocusIdx(i); focusIdxRef.current = i; }}
+            style={{
+              padding: "12px 24px",
+              cursor: "pointer",
+              fontSize: 14,
+              fontWeight: 500,
+              color: focusIdx === collections.length ? accent.primary : theme.textFaint,
+              background: focusIdx === collections.length
+                ? (isDark ? "rgba(255,255,255,0.05)" : "rgba(0,0,0,0.03)")
+                : "transparent",
+              borderLeft: `3px solid ${focusIdx === collections.length ? accent.primary : "transparent"}`,
+              transition: "background 0.1s, border-color 0.1s, color 0.1s",
+            }}
+          >
+            + {t("collections.newPlaceholder")}
+          </div>
+        </div>
+      </ModalShell>
+
+      {confirmDeleteCol && (
+        <ConfirmModal
+          message={t("confirm.deleteCollection", { name: confirmDeleteCol.name })}
+          onConfirm={() => {
+            onDeleteCollectionRef.current(confirmDeleteCol!.id);
+            setConfirmDeleteCol(null);
+            confirmDeleteColRef.current = null;
+          }}
+          onCancel={() => { setConfirmDeleteCol(null); confirmDeleteColRef.current = null; }}
+          glass={glass} accent={accent} theme={theme} isDark={isDark}
+        />
+      )}
+
+      {showKb && (
+        <GamepadKeyboard
+          value={kbValue}
+          onChange={(v) => { setKbValue(v); kbValueRef.current = v; }}
+          onClose={() => {
+            setShowKb(false);
+            showKbRef.current = false;
+            const name = kbValueRef.current.trim();
+            setKbValue("");
+            kbValueRef.current = "";
+            if (name) onCreateCollectionRef.current(name);
+          }}
+          title={t("collections.newPlaceholder")}
+          accent={accent} theme={theme} isDark={isDark} glass={glass}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ModalShell from "./ModalShell";
+
+interface Props {
+  message: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+}
+
+export default function ConfirmModal({ message, confirmLabel, onConfirm, onCancel, glass, accent, theme, isDark }: Props) {
+  const { t } = useTranslation();
+  const label = confirmLabel ?? t("confirm.yes");
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        if (state.Enter  && !last.Enter)  { onConfirm(); }
+        if (state.Escape && !last.Escape) { onCancel(); }
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shortcuts = [
+    { btn: "A", label },
+    { btn: "B", label: t("common.cancel") },
+  ];
+
+  return (
+    <ModalShell
+      title={message}
+      shortcuts={shortcuts}
+      glass={glass} accent={accent} theme={theme} isDark={isDark}
+      width={380}
+      zIndex={2500}
+    />
+  );
+}

--- a/src/components/modals/ContextMenuModal.tsx
+++ b/src/components/modals/ContextMenuModal.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ModalShell from "./ModalShell";
+
+interface MenuItem {
+  label: string;
+  action: () => void;
+  danger?: boolean;
+}
+
+interface App {
+  id: string;
+  name: string;
+  [key: string]: any;
+}
+
+interface Props {
+  app: App;
+  items: MenuItem[];
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  onClose: () => void;
+}
+
+export default function ContextMenuModal({ app, items, glass, accent, theme, isDark, onClose }: Props) {
+  const { t } = useTranslation();
+  const [focusIdx, setFocusIdx] = useState(0);
+  const focusIdxRef = useRef(0);
+  const itemsRef    = useRef(items);
+  useEffect(() => { itemsRef.current = items; }, [items]);
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        if (state.ArrowDown && !last.ArrowDown) {
+          const next = Math.min(focusIdxRef.current + 1, itemsRef.current.length - 1);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.ArrowUp && !last.ArrowUp) {
+          const next = Math.max(focusIdxRef.current - 1, 0);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.Enter && !last.Enter) {
+          itemsRef.current[focusIdxRef.current]?.action();
+        }
+        if (state.Escape && !last.Escape) { onClose(); }
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shortcuts = [
+    { btn: "A",  label: t("gamepad.aSelect") },
+    { btn: "B",  label: t("common.close") },
+  ];
+
+  return (
+    <ModalShell
+      title={app.name}
+      shortcuts={shortcuts}
+      glass={glass} accent={accent} theme={theme} isDark={isDark}
+      width={280}
+      zIndex={9000}
+      onOverlayClick={onClose}
+    >
+      <div style={{ padding: "8px 0" }}>
+        {items.map(({ label, action, danger }, i) => {
+          const focused = focusIdx === i;
+          return (
+            <div
+              key={label}
+              onClick={action}
+              onMouseEnter={() => { setFocusIdx(i); focusIdxRef.current = i; }}
+              style={{
+                padding: "12px 24px",
+                cursor: "pointer",
+                fontSize: 14,
+                fontWeight: 500,
+                color: danger ? "#e85a5a" : theme.text,
+                background: focused
+                  ? (danger ? "rgba(232,90,90,0.1)" : (isDark ? "rgba(255,255,255,0.07)" : "rgba(0,0,0,0.05)"))
+                  : "transparent",
+                borderLeft: `3px solid ${focused ? (danger ? "#e85a5a" : accent.primary) : "transparent"}`,
+                transition: "background 0.1s, border-color 0.1s",
+              }}
+            >
+              {label}
+            </div>
+          );
+        })}
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/components/modals/FolderManagerModal.tsx
+++ b/src/components/modals/FolderManagerModal.tsx
@@ -1,0 +1,163 @@
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ConfirmModal from "./ConfirmModal";
+import ModalShell from "./ModalShell";
+
+interface Folder {
+  id: string;
+  path: string;
+  source: string;
+  app_type: string;
+  enabled?: boolean;
+}
+
+interface Props {
+  customFolders: Folder[];
+  onToggle: (id: string, enabled: boolean) => void;
+  onDelete: (id: string) => void;
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  onClose: () => void;
+}
+
+export default function FolderManagerModal({ customFolders, onToggle, onDelete, glass, accent, theme, isDark, onClose }: Props) {
+  const { t } = useTranslation();
+  const [focusIdx, setFocusIdx]           = useState(0);
+  const [confirmFolder, setConfirmFolder] = useState<Folder | null>(null);
+  const focusIdxRef = useRef(0);
+  const confirmRef  = useRef<Folder | null>(null);
+
+  const gameFolders = customFolders.filter(f => f.app_type === "game");
+  const appFolders  = customFolders.filter(f => f.app_type !== "game");
+  const allFolders  = [...gameFolders, ...appFolders];
+
+  const allFoldersRef = useRef(allFolders);
+  useEffect(() => { allFoldersRef.current = allFolders; });
+
+  useEffect(() => {
+    const last: any = {};
+    let rafId: number;
+    let suppressFrames = 20;
+    const poll = () => {
+      if (suppressFrames > 0) { suppressFrames--; rafId = requestAnimationFrame(poll); return; }
+      if (confirmRef.current) { rafId = requestAnimationFrame(poll); return; }
+      const gp = getBestGamepad();
+      if (gp) {
+        const state = readGpState(gp);
+        if (state.Escape && !last.Escape) { onClose(); }
+        if (state.ArrowDown && !last.ArrowDown) {
+          const next = Math.min(focusIdxRef.current + 1, allFoldersRef.current.length - 1);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.ArrowUp && !last.ArrowUp) {
+          const next = Math.max(focusIdxRef.current - 1, 0);
+          setFocusIdx(next); focusIdxRef.current = next;
+        }
+        if (state.Enter && !last.Enter) {
+          const folder = allFoldersRef.current[focusIdxRef.current];
+          if (folder) onToggle(folder.id, folder.enabled !== false ? false : true);
+        }
+        if (state.ButtonX && !last.ButtonX) {
+          const folder = allFoldersRef.current[focusIdxRef.current];
+          if (folder) { setConfirmFolder(folder); confirmRef.current = folder; }
+        }
+        Object.assign(last, state);
+      }
+      rafId = requestAnimationFrame(poll);
+    };
+    rafId = requestAnimationFrame(poll);
+    return () => cancelAnimationFrame(rafId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shortcuts = [
+    { btn: "A",  label: t("shortcuts.toggle") },
+    { btn: "X",  label: t("common.delete") },
+    { btn: "B",  label: t("common.close") },
+  ];
+
+  const renderGroup = (folders: Folder[], label: string, startIdx: number) => {
+    if (folders.length === 0) return null;
+    return (
+      <div key={label}>
+        <div style={{
+          fontSize: 10, fontWeight: 700, color: theme.textFaint,
+          textTransform: "uppercase", letterSpacing: "0.1em",
+          padding: "10px 20px 4px",
+        }}>
+          {label}
+        </div>
+        {folders.map((folder, i) => {
+          const globalIdx = startIdx + i;
+          const focused = focusIdx === globalIdx;
+          return (
+            <div key={folder.id} style={{
+              display: "flex", alignItems: "center", gap: 10, padding: "10px 20px",
+              background: focused ? `${accent.glow}0.15)` : "transparent",
+              borderLeft: `3px solid ${focused ? accent.primary : "transparent"}`,
+              transition: "background 0.1s",
+            }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontSize: 12,
+                  color: folder.enabled !== false ? theme.text : theme.textFaint,
+                  overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                }}>
+                  {folder.path}
+                </div>
+                <div style={{ fontSize: 10, color: theme.textFaint, marginTop: 1 }}>{folder.source}</div>
+              </div>
+              <div
+                onClick={() => onToggle(folder.id, folder.enabled !== false ? false : true)}
+                style={{
+                  width: 36, height: 20, borderRadius: 10,
+                  background: folder.enabled !== false ? accent.primary : (isDark ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.15)"),
+                  position: "relative", cursor: "pointer", flexShrink: 0,
+                }}>
+                <div style={{
+                  width: 14, height: 14, borderRadius: "50%", background: "white",
+                  position: "absolute", top: 3,
+                  left: folder.enabled !== false ? 19 : 3,
+                  transition: "left 0.2s",
+                  boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
+                }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <ModalShell
+        title={t("settings.customFolders")}
+        shortcuts={shortcuts}
+        glass={glass} accent={accent} theme={theme} isDark={isDark}
+        width={560}
+        maxHeight="70vh"
+        zIndex={2000}
+      >
+        {allFolders.length === 0 && (
+          <div style={{ padding: "32px 24px", textAlign: "center", color: theme.textFaint, fontSize: 13, fontStyle: "italic" }}>
+            {t("settings.noCustomFolders")}
+          </div>
+        )}
+        {renderGroup(gameFolders, t("tabs.games").toUpperCase(), 0)}
+        {renderGroup(appFolders,  t("tabs.apps").toUpperCase(),  gameFolders.length)}
+      </ModalShell>
+
+      {confirmFolder && (
+        <ConfirmModal
+          message={t("confirm.deleteFolder")}
+          onConfirm={() => { onDelete(confirmFolder!.id); setConfirmFolder(null); confirmRef.current = null; }}
+          onCancel={() => { setConfirmFolder(null); confirmRef.current = null; }}
+          glass={glass} accent={accent} theme={theme} isDark={isDark}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/modals/HideModal.tsx
+++ b/src/components/modals/HideModal.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { getBestGamepad, readGpState } from "../../utils/gamepad";
+import ModalShell from "./ModalShell";
+
+interface App {
+  id: string;
+  name: string;
+  app_type?: string;
+  source?: string;
+  icon_base64?: string;
+  [key: string]: any;
+}
+
+interface Props {
+  tab: string;
+  appsRef: React.RefObject<App[]>;
+  hiddenRef: React.RefObject<string[]>;
+  allAppsRef: React.RefObject<App[]>;
+  closeHideModal: () => void;
+  toggleHidden: (id: string) => void;
+  glass: any;
+  accent: any;
+  isDark: boolean;
+  theme: any;
+}
+
+export default function HideModal({ tab, appsRef, hiddenRef, allAppsRef, closeHideModal, toggleHidden, glass, accent, isDark, theme }: Props) {
+  const { t } = useTranslation();
+  const visibleApps = appsRef.current.filter(a => tab === "Games" ? a.app_type === "game" : a.app_type === "app");
+  const hiddenIds   = hiddenRef.current;
+
+  const [localChecked, setLocalChecked] = useState(() => new Set(visibleApps.map(a => a.id)));
+  const [focusIdx, setFocusIdx] = useState(0);
+  const focusIdxRef = useRef(0);
+  const listRef     = useRef<HTMLDivElement>(null);
+
+  const hiddenApps = hiddenIds.map(id => {
+    const full = allAppsRef.current.find(a => a.id === id);
+    return full ? { ...full, _hidden: true } : { id, name: id, _hidden: true };
+  }).filter((a: any) => tab === "Games" ? a.app_type === "game" : a.app_type === "app" || !a.app_type);
+  const allItems = [...visibleApps.map(a => ({ ...a, _hidden: false })), ...hiddenApps];
+
+  const allItemsRef     = useRef(allItems);
+  const localCheckedRef = useRef(localChecked);
+  useEffect(() => { allItemsRef.current     = allItems;     });
+  useEffect(() => { localCheckedRef.current = localChecked; });
+
+  useEffect(() => {
+    if (listRef.current) {
+      const rows = listRef.current.querySelectorAll("[data-modal-row]");
+      if (rows[focusIdx]) (rows[focusIdx] as HTMLElement).scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [focusIdx]);
+
+  useEffect(() => {
+    let closed = false;
+
+    const toggleItem = (i: number) => {
+      const item = allItemsRef.current[i];
+      if (!item) return;
+      setLocalChecked(prev => { const n = new Set(prev); n.has(item.id) ? n.delete(item.id) : n.add(item.id); return n; });
+    };
+
+    const doClose = () => { closed = true; closeHideModal(); };
+
+    const doConfirm = () => {
+      closed = true;
+      const checked = localCheckedRef.current;
+      const items   = allItemsRef.current;
+      items.filter((a: any) => !a._hidden && !checked.has(a.id)).forEach((a: any) => toggleHidden(a.id));
+      items.filter((a: any) =>  a._hidden &&  checked.has(a.id)).forEach((a: any) => toggleHidden(a.id));
+      closeHideModal();
+    };
+
+    const handle = (key: string) => {
+      if (closed) return;
+      const total = allItemsRef.current.length;
+      if      (key === "ArrowDown" || key === "ArrowRight") { const ni = Math.min(focusIdxRef.current + 1, total - 1); setFocusIdx(ni); focusIdxRef.current = ni; }
+      else if (key === "ArrowUp"   || key === "ArrowLeft")  { const ni = Math.max(focusIdxRef.current - 1, 0);         setFocusIdx(ni); focusIdxRef.current = ni; }
+      else if (key === "Enter")  toggleItem(focusIdxRef.current);
+      else if (key === "Start")  doConfirm();
+      else if (key === "Escape") doClose();
+    };
+
+    const onKey = (e: KeyboardEvent) => {
+      if (closed) return;
+      const map: Record<string, string> = { ArrowDown:"ArrowDown", ArrowUp:"ArrowUp", ArrowLeft:"ArrowLeft", ArrowRight:"ArrowRight", Enter:"Enter", Escape:"Escape", " ":"Enter" };
+      if (map[e.key]) { e.preventDefault(); e.stopPropagation(); handle(map[e.key]); }
+    };
+    window.addEventListener("keydown", onKey, true);
+
+    let rAF: number;
+    const lastBtn: any   = {};
+    const pressTime: any = {};
+    const repeating: any = {};
+    const DIRS      = new Set(["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"]);
+    const INIT_MS   = 400;
+    const RPT_MS    = 100;
+    let startReleased = false;
+    let enterReleased = false;
+
+    const pollModal = (now: number) => {
+      if (closed) return;
+      const gp  = getBestGamepad();
+      if (gp) {
+        const base = readGpState(gp);
+        if (!base.Start) startReleased = true;
+        if (!base.Enter) enterReleased = true;
+        const state = { ...base, Start: startReleased && base.Start, Enter: enterReleased && base.Enter };
+        Object.keys(state).forEach(k => {
+          const pressed = (state as any)[k], was = lastBtn[k];
+          if (pressed && !was) {
+            handle(k); pressTime[k] = now; repeating[k] = false;
+          } else if (pressed && was && DIRS.has(k)) {
+            const held = now - (pressTime[k] || now);
+            if (!repeating[k] && held >= INIT_MS) { repeating[k] = true; pressTime[k] = now; handle(k); }
+            else if (repeating[k] && held >= RPT_MS) { pressTime[k] = now; handle(k); }
+          } else if (!pressed && was) { pressTime[k] = 0; repeating[k] = false; }
+          lastBtn[k] = pressed;
+        });
+      }
+      rAF = requestAnimationFrame(pollModal);
+    };
+    rAF = requestAnimationFrame(pollModal);
+
+    return () => { closed = true; window.removeEventListener("keydown", onKey, true); cancelAnimationFrame(rAF); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const shortcuts = [
+    { btn: "A",   label: t("hideModal.shortcutToggle") },
+    { btn: "MENU", label: t("shortcuts.save") },
+    { btn: "B",   label: t("common.cancel") },
+  ];
+
+  return (
+    <ModalShell
+      title={tab === "Games" ? t("hideModal.manageGames") : t("hideModal.manageApps")}
+      shortcuts={shortcuts}
+      glass={glass} accent={accent} theme={theme} isDark={isDark}
+      width={600}
+      maxHeight="75vh"
+      zIndex={8500}
+    >
+      <div ref={listRef} style={{ overflowY: "auto", padding: "8px 0" }}>
+        {allItems.length === 0 && (
+          <div style={{ padding: "40px 24px", textAlign: "center", color: theme.textFaint, fontSize: 13 }}>{t("hideModal.noApps")}</div>
+        )}
+        {allItems.map((item: any, i) => {
+          const checked  = localChecked.has(item.id);
+          const rowFocus = focusIdx === i;
+          const isHidden = item._hidden;
+          return (
+            <div key={item.id} data-modal-row
+              onClick={() => { setFocusIdx(i); focusIdxRef.current = i; setLocalChecked(prev => { const n = new Set(prev); checked ? n.delete(item.id) : n.add(item.id); return n; }); }}
+              style={{ display: "flex", alignItems: "center", gap: 14, padding: "10px 24px", cursor: "pointer",
+                background: rowFocus ? `${accent.glow}0.12)` : "transparent",
+                borderLeft: `3px solid ${rowFocus ? accent.primary : "transparent"}`,
+                opacity: isHidden && !checked ? 0.5 : 1,
+                transition: "all 0.1s ease" }}>
+              <div style={{ width: 20, height: 20, borderRadius: 5, flexShrink: 0,
+                border: `2px solid ${checked ? accent.primary : (isDark ? "rgba(255,255,255,0.25)" : "rgba(0,0,0,0.2)")}`,
+                background: checked ? accent.primary : "transparent",
+                display: "flex", alignItems: "center", justifyContent: "center", transition: "all 0.1s ease" }}>
+                {checked && <svg width="11" height="11" viewBox="0 0 12 12" fill="none"><path d="M2 6l3 3 5-5" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>}
+              </div>
+              {item.icon_base64
+                ? <div style={{ width: 28, height: 28, borderRadius: 6, overflow: "hidden", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+                    <img src={`data:image/png;base64,${item.icon_base64}`} alt={item.name} style={{ width: "100%", height: "100%", maxWidth: "100%", maxHeight: "100%", objectFit: "contain", objectPosition: "center", display: "block" }} />
+                  </div>
+                : <div style={{ width: 28, height: 28, borderRadius: 6, background: `${accent.glow}0.15)`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, color: accent.primary, flexShrink: 0 }}>{(item.name || "?")[0]}</div>
+              }
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 500, color: theme.text, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {item.name || item.id}
+                </div>
+                <div style={{ fontSize: 10, color: theme.textFaint, textTransform: "capitalize" }}>
+                  {isHidden ? `${item.source || "hidden"}` : item.source}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </ModalShell>
+  );
+}

--- a/src/components/modals/ModalShell.tsx
+++ b/src/components/modals/ModalShell.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from "react";
+import { GamepadBtn } from "../GamepadBtn";
+
+export interface ShortcutItem {
+  btn: string;
+  label: string;
+}
+
+interface ModalShellProps {
+  title: string;
+  children?: ReactNode;
+  shortcuts?: ShortcutItem[];
+  glass: any;
+  accent: any;
+  theme: any;
+  isDark: boolean;
+  width?: number;
+  maxHeight?: string;
+  zIndex?: number;
+  onOverlayClick?: () => void;
+}
+
+export default function ModalShell({
+  title,
+  children,
+  shortcuts = [],
+  glass,
+  accent,
+  theme,
+  isDark,
+  width = 480,
+  maxHeight,
+  zIndex = 2000,
+  onOverlayClick,
+}: ModalShellProps) {
+  const hasBody = children != null && children !== false;
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, zIndex,
+        background: "rgba(0,0,0,0.7)",
+        backdropFilter: "blur(16px)", WebkitBackdropFilter: "blur(16px)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontFamily: "'Segoe UI', sans-serif", userSelect: "none",
+      }}
+      onClick={onOverlayClick}
+    >
+      <div
+        style={{
+          ...glass,
+          width: `min(${width}px, 90vw)`,
+          ...(maxHeight ? { maxHeight } : {}),
+          borderRadius: 20,
+          display: "flex", flexDirection: "column",
+          overflow: "hidden",
+          border: `1px solid ${accent.glow}0.3)`,
+          boxShadow: "0 8px 48px rgba(0,0,0,0.6)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{
+          padding: "20px 24px 14px", flexShrink: 0,
+          ...(hasBody ? { borderBottom: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}` } : {}),
+        }}>
+          <div style={{ fontSize: 15, fontWeight: 700, color: theme.text }}>{title}</div>
+        </div>
+
+        {hasBody && (
+          <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+            {children}
+          </div>
+        )}
+
+        {shortcuts.length > 0 && (
+          <div style={{
+            padding: "10px 20px", flexShrink: 0,
+            borderTop: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.07)"}`,
+            display: "flex", gap: 16, flexWrap: "wrap", alignItems: "center",
+          }}>
+            {shortcuts.map(({ btn, label }, i) => (
+              <GamepadBtn key={`${btn}-${i}`} btn={btn} label={label} theme={theme} isDark={isDark} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -45,7 +45,8 @@
     "noApps": "No apps found.",
     "saveChanges_one": "Save {{count}} change",
     "saveChanges_other": "Save {{count}} changes",
-    "save": "Save"
+    "save": "Save",
+    "shortcutToggle": "Hide/Show"
   },
   "settings": {
     "accentColor": "Accent Color",
@@ -66,6 +67,8 @@
     "scanDesktop": "Scan Desktop Shortcuts",
     "scanBattlenet": "Scan Battle.net",
     "refreshLibrary": "Refresh Library",
+    "customFolders": "Custom scan folders",
+    "noCustomFolders": "No custom folders configured",
     "defaultTab": "Default Tab",
     "repeatSpeed": "Stick Repeat Speed",
     "launchAtStartup": "Launch at Startup",
@@ -173,7 +176,11 @@
     "pin": "Pin",
     "unpin": "Unpin",
     "changeArt": "Change Art",
-    "changeHeroArt": "Change Hero Art"
+    "changeHeroArt": "Change Hero Art",
+    "collections": "Manage Collections",
+    "hide": "Hide",
+    "show": "Show",
+    "delete": "Delete"
   },
   "gamepad": {
     "aSelect": "A Select",
@@ -203,6 +210,61 @@
     "clear": "Clear",
     "close": "Close",
     "select": "Select",
-    "retry": "Retry"
+    "retry": "Retry",
+    "add": "Add",
+    "saving": "Saving…",
+    "back": "Back",
+    "done": "Done",
+    "delete": "Delete"
+  },
+  "confirm": {
+    "deleteApp": "Remove {{name}} from your library?",
+    "deleteFolder": "Remove this scan folder?",
+    "deleteCollection": "Delete collection \"{{name}}\"?",
+    "yes": "Delete"
+  },
+  "collections": {
+    "manage": "Manage Collections",
+    "manageGames": "Game Collections",
+    "manageApps": "App Collections",
+    "empty": "No collections yet",
+    "none": "No collections — create one via Manage",
+    "newPlaceholder": "New collection name…",
+    "assign": "Collections for {{name}}"
+  },
+  "fileBrowser": {
+    "selectFile": "Select a file",
+    "selectFolder": "Select a folder",
+    "drives": "Drives",
+    "empty": "Empty folder",
+    "navigate": "Navigate",
+    "open": "Open",
+    "select": "Select",
+    "selectThis": "↵ Select this folder"
+  },
+  "shortcuts": {
+    "navigate": "Navigate",
+    "keyboard": "Keyboard",
+    "toggle": "Toggle",
+    "confirm": "Confirm",
+    "save": "Save",
+    "select": "Select"
+  },
+  "addEntry": {
+    "addEntry": "Add a game / app",
+    "addGame": "Add a game",
+    "addApp": "Add an app",
+    "addFolder": "Add a scan folder",
+    "path": "Path",
+    "name": "Name",
+    "type": "Type",
+    "typeGame": "Game",
+    "typeApp": "App",
+    "source": "Source / List",
+    "newSource": "New list",
+    "newSourcePlaceholder": "List name…",
+    "collection": "Collection",
+    "newCollection": "New collection",
+    "newCollectionPlaceholder": "Collection name…"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -45,7 +45,8 @@
     "noApps": "Aucune app trouvée.",
     "saveChanges_one": "Sauvegarder {{count}} modification",
     "saveChanges_other": "Sauvegarder {{count}} modifications",
-    "save": "Sauvegarder"
+    "save": "Sauvegarder",
+    "shortcutToggle": "Masquer/Afficher"
   },
   "settings": {
     "accentColor": "Couleur d'accent",
@@ -66,6 +67,8 @@
     "scanDesktop": "Scanner les raccourcis Bureau",
     "scanBattlenet": "Scanner Battle.net",
     "refreshLibrary": "Actualiser la bibliothèque",
+    "customFolders": "Dossiers de scan personnalisés",
+    "noCustomFolders": "Aucun dossier personnalisé configuré",
     "defaultTab": "Onglet par défaut",
     "repeatSpeed": "Vitesse de répétition",
     "launchAtStartup": "Lancer au démarrage",
@@ -173,7 +176,11 @@
     "pin": "Épingler",
     "unpin": "Désépingler",
     "changeArt": "Changer l'illustration",
-    "changeHeroArt": "Changer l'art héros"
+    "changeHeroArt": "Changer l'art héros",
+    "collections": "Gérer les collections",
+    "hide": "Masquer",
+    "show": "Afficher",
+    "delete": "Supprimer"
   },
   "gamepad": {
     "aSelect": "A Sélectionner",
@@ -203,6 +210,61 @@
     "clear": "Effacer",
     "close": "Fermer",
     "select": "Sélectionner",
-    "retry": "Réessayer"
+    "retry": "Réessayer",
+    "add": "Ajouter",
+    "saving": "Sauvegarde…",
+    "back": "Retour",
+    "done": "Terminé",
+    "delete": "Supprimer"
+  },
+  "confirm": {
+    "deleteApp": "Retirer {{name}} de votre bibliothèque ?",
+    "deleteFolder": "Supprimer ce dossier de scan ?",
+    "deleteCollection": "Supprimer la collection « {{name}} » ?",
+    "yes": "Supprimer"
+  },
+  "collections": {
+    "manage": "Gérer les collections",
+    "manageGames": "Collections de jeux",
+    "manageApps": "Collections d'apps",
+    "empty": "Aucune collection",
+    "none": "Aucune collection — créez-en une via Gérer",
+    "newPlaceholder": "Nom de la nouvelle collection…",
+    "assign": "Collections de {{name}}"
+  },
+  "fileBrowser": {
+    "selectFile": "Sélectionner un fichier",
+    "selectFolder": "Sélectionner un dossier",
+    "drives": "Lecteurs",
+    "empty": "Dossier vide",
+    "navigate": "Naviguer",
+    "open": "Ouvrir",
+    "select": "Sélectionner",
+    "selectThis": "↵ Sélectionner ce dossier"
+  },
+  "shortcuts": {
+    "navigate": "Naviguer",
+    "keyboard": "Clavier",
+    "toggle": "Act./Dés.",
+    "confirm": "Confirmer",
+    "save": "Sauvegarder",
+    "select": "Sélectionner"
+  },
+  "addEntry": {
+    "addEntry": "Ajouter un jeu / une app",
+    "addGame": "Ajouter un jeu",
+    "addApp": "Ajouter une app",
+    "addFolder": "Ajouter un dossier à scanner",
+    "path": "Chemin",
+    "name": "Nom",
+    "type": "Type",
+    "typeGame": "Jeu",
+    "typeApp": "App",
+    "source": "Source / Liste",
+    "newSource": "Nouvelle liste",
+    "newSourcePlaceholder": "Nom de la liste…",
+    "collection": "Collection",
+    "newCollection": "Nouvelle collection",
+    "newCollectionPlaceholder": "Nom de la collection…"
   }
 }

--- a/src/utils/gamepad.js
+++ b/src/utils/gamepad.js
@@ -1,0 +1,32 @@
+export function getBestGamepad() {
+  const gps = Array.from(navigator.getGamepads()).filter(Boolean);
+  return (
+    gps.find(gp => gp.mapping === "standard" && gp.axes.length >= 4) ||
+    gps.find(gp => gp.buttons.length >= 4    && gp.axes.length >= 4) ||
+    gps[0] || null
+  );
+}
+
+export function readGpState(gp) {
+  const btn = (i) => !!gp.buttons[i]?.pressed;
+  const hatLeft  = (gp.axes[6] ?? 0) < -0.5;
+  const hatRight = (gp.axes[6] ?? 0) >  0.5;
+  const hatUp    = (gp.axes[7] ?? 0) < -0.5;
+  const hatDown  = (gp.axes[7] ?? 0) >  0.5;
+  return {
+    ArrowUp:      btn(12) || hatUp    || gp.axes[1] < -0.5,
+    ArrowDown:    btn(13) || hatDown  || gp.axes[1] >  0.5,
+    ArrowLeft:    btn(14) || hatLeft  || gp.axes[0] < -0.5,
+    ArrowRight:   btn(15) || hatRight || gp.axes[0] >  0.5,
+    Enter:        btn(0),
+    Escape:       btn(1),
+    ButtonX:      btn(2),
+    ButtonY:      btn(3),
+    BumperLeft:   btn(4),
+    BumperRight:  btn(5),
+    TriggerLeft:  btn(6),
+    TriggerRight: btn(7),
+    Select:       btn(8),
+    Start:        btn(9),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": false,
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
- Scan custom folders at startup to discover games and apps
- Manually add individual games or apps via file picker
- Assign entries to existing collections or create new ones on add
- Manage scan folders (enable/disable, delete) from settings
- Extract all modals to src/components/modals/ as TypeScript components
- Add ModalShell (shared glass shell with gamepad shortcut footer)
- Fix collection picker, folder scan source tagging, and post-scan membership assignment